### PR TITLE
feat: add vehicle types and resource claiming

### DIFF
--- a/tilearmy/public/index.html
+++ b/tilearmy/public/index.html
@@ -28,7 +28,8 @@
   <header>
     <h1>TileArmy</h1>
     <div class="row">
-      <button id="spawn" class="primary">Spawn Vehicle (-1000)</button>
+      <select id="vehicleType"></select>
+      <button id="spawn" class="primary">Spawn Vehicle</button>
       <button id="toggleFollow">Follow: On</button>
       <span id="pid" class="pill"></span>
       <div id="stats" class="pill">Res: <span id="resCount">0</span></div>
@@ -41,7 +42,7 @@
       <h2>Your Vehicles</h2>
       <div id="vehicles"></div>
       <h2>Tips</h2>
-      <div>• Use WASD to move the camera. Press H to center on your base.<br>• Toggle camera follow to manually watch any spot.<br>• Resources change color as they deplete. Vehicles cost 1000.</div>
+      <div>• Use WASD to move the camera. Press H to center on your base.<br>• Toggle camera follow to manually watch any spot.<br>• Resources change color as they deplete. Different vehicles have different costs.</div>
     </aside>
   </div>
   <div id="toast"></div>


### PR DESCRIPTION
## Summary
- prevent multiple vehicles from targeting same resource
- support multiple vehicle types with distinct stats and costs
- allow players to choose vehicle type when spawning

## Testing
- `node --check server.js`
- `node --check public/client.js`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689d8fefd82c8327a5e1efa2efe35460