### PR TITLE
Add ore, lumber, and stone resource types with SVG assets

### DIFF
--- a/tilearmy/public/img/base.svg
+++ b/tilearmy/public/img/base.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
+  <rect x="8" y="14" width="24" height="18" fill="#4b528b" stroke="#ffffff" stroke-width="2"/>
+  <path d="M20 6 L6 16 H34 Z" fill="#ffc857" stroke="#ffffff" stroke-width="2"/>
+</svg>

--- a/tilearmy/public/img/basic.svg
+++ b/tilearmy/public/img/basic.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
+  <circle cx="20" cy="20" r="12" fill="#ffffff" stroke="#111" stroke-width="2"/>
+</svg>

--- a/tilearmy/public/img/hauler.svg
+++ b/tilearmy/public/img/hauler.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
+  <rect x="4" y="10" width="32" height="20" rx="4" fill="#ffb3d1" stroke="#111" stroke-width="2"/>
+  <circle cx="12" cy="30" r="4" fill="#333"/>
+  <circle cx="28" cy="30" r="4" fill="#333"/>
+</svg>

--- a/tilearmy/public/img/lumber.svg
+++ b/tilearmy/public/img/lumber.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
+  <rect x="8" y="14" width="24" height="12" rx="2" fill="#b45309" stroke="#111" stroke-width="2"/>
+  <circle cx="12" cy="20" r="2" fill="#92400e"/>
+  <circle cx="28" cy="20" r="2" fill="#92400e"/>
+</svg>

--- a/tilearmy/public/img/ore.svg
+++ b/tilearmy/public/img/ore.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
+  <path d="M12 28 L8 18 L16 8 L28 12 L32 24 L22 32 Z" fill="#9ca3af" stroke="#111" stroke-width="2"/>
+</svg>

--- a/tilearmy/public/img/scout.svg
+++ b/tilearmy/public/img/scout.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
+  <polygon points="20,6 34,34 6,34" fill="#9be9ff" stroke="#111" stroke-width="2"/>
+</svg>

--- a/tilearmy/public/img/stone.svg
+++ b/tilearmy/public/img/stone.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
+  <path d="M10 30 L6 20 L12 10 L22 8 L30 14 L32 24 L24 32 Z" fill="#6b7280" stroke="#111" stroke-width="2"/>
+</svg>

--- a/tilearmy/public/index.html
+++ b/tilearmy/public/index.html
@@ -32,7 +32,7 @@
       <button id="spawn" class="primary">Spawn Vehicle</button>
       <button id="toggleFollow">Follow: On</button>
       <span id="pid" class="pill"></span>
-      <div id="stats" class="pill">Res: <span id="resCount">0</span></div>
+      <div id="stats" class="pill">Ore: <span id="oreCount">0</span> | Lumber: <span id="lumberCount">0</span> | Stone: <span id="stoneCount">0</span></div>
       <div id="energyBar"><div id="energyFill"></div></div>
     </div>
   </header>
@@ -42,7 +42,7 @@
       <h2>Your Vehicles</h2>
       <div id="vehicles"></div>
       <h2>Tips</h2>
-      <div>• Use WASD to move the camera. Press H to center on your base.<br>• Toggle camera follow to manually watch any spot.<br>• Resources change color as they deplete. Different vehicles have different costs.</div>
+      <div>• Use WASD to move the camera. Press H to center on your base.<br>• Toggle camera follow to manually watch any spot.<br>• Resource icons fade as they deplete. Different vehicles have different costs.</div>
     </aside>
   </div>
   <div id="toast"></div>


### PR DESCRIPTION
## Summary
- support multiple resource types (ore, lumber, stone) and track them per player
- add SVG icons for base, vehicles, and resource tiles, updating client rendering and UI
## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d93d9eda88327acc31ad7a74e6759