### PR TITLE
Use SVG sprite icons with team colors

### DIFF
--- a/tilearmy/server.js
+++ b/tilearmy/server.js
@@ -213,6 +213,8 @@ setInterval(() => {
 }, CFG.TICK_MS);
 
 // ------------------ STATIC + START ------------------
+// Serve SVG asset sheet for client-side icon rendering
+app.use('/assets', express.static(path.join(__dirname, 'assets')));
 app.use(express.static(path.join(__dirname, 'public')));
 app.get('/cfg.json', (_req, res) => res.json({ VIEW_W: 1000, VIEW_H: 700 }));
 


### PR DESCRIPTION
## Summary
- Serve SVG asset sheet and load icons via DOM to generate images
- Render bases and vehicles with team-colored SVG sprites from the shared sheet

## Testing
- `npm test` *(fails: Missing script "test")*
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_689daa3b1920832795ff230f206495b8