### PR TITLE
feat: add arrow key navigation and map zoom controls

### DIFF
--- a/tilearmy/README.md
+++ b/tilearmy/README.md
@@ -21,6 +21,6 @@ TileArmy is a browser-based real-time resource-gathering game built with Node.js
 - **Automatic harvesting** – Idle vehicles automatically seek the nearest unclaimed resource. Once full, they return to your base to unload.
 - **Manual commands** – Click on the map to move the selected vehicle. Use the dropdown to spawn different vehicle types.
 - **Energy** – Movement consumes energy. Your energy reserve slowly regenerates over time.
-- **Camera** – Toggle the "Follow" button to keep the view centered on your selected vehicle, or use WASD to pan manually. Press `H` to jump back to your base.
+- **Camera** – Toggle the "Follow" button to keep the view centered on your selected vehicle, or use WASD/arrow keys to pan manually. Use `+`/`-` to zoom, `F` to toggle fullscreen, and press `H` to jump back to your base.
 
 Happy harvesting!

--- a/tilearmy/public/client.js
+++ b/tilearmy/public/client.js
@@ -138,12 +138,36 @@
   function toWorld(px,py){
     return { x: px / camera.scale + camera.x, y: py / camera.scale + camera.y };
   }
+  function zoom(factor){
+    const prev = camera.scale;
+    camera.scale = Math.max(0.5, Math.min(3, camera.scale * factor));
+    const mx = camera.x + (canvas.width / prev)/2;
+    const my = camera.y + (canvas.height / prev)/2;
+    camera.x = mx - (canvas.width / camera.scale)/2;
+    camera.y = my - (canvas.height / camera.scale)/2;
+    camera.x = Math.max(0, Math.min(camera.x, state.cfg.MAP_W - canvas.width / camera.scale));
+    camera.y = Math.max(0, Math.min(camera.y, state.cfg.MAP_H - canvas.height / camera.scale));
+  }
 
   window.addEventListener('keydown', (e) => {
     const k = e.key.toLowerCase();
-    if (['w','a','s','d'].includes(k)) {
-      keys[k] = true;
+    const map = { arrowup:'w', arrowdown:'s', arrowleft:'a', arrowright:'d' };
+    if (['w','a','s','d'].includes(k) || map[k]) {
+      keys[map[k] || k] = true;
       camera.follow = false;
+      e.preventDefault();
+    } else if (k === '+' || k === '=') {
+      zoom(1.2);
+      e.preventDefault();
+    } else if (k === '-') {
+      zoom(1/1.2);
+      e.preventDefault();
+    } else if (k === 'f') {
+      if (!document.fullscreenElement) {
+        canvas.requestFullscreen().catch(()=>{});
+      } else {
+        document.exitFullscreen().catch(()=>{});
+      }
       e.preventDefault();
     } else if (k === 'h') {
       const me = state.players[myId];
@@ -159,7 +183,9 @@
   });
   window.addEventListener('keyup', (e) => {
     const k = e.key.toLowerCase();
-    if (keys[k]) delete keys[k];
+    const map = { arrowup:'w', arrowdown:'s', arrowleft:'a', arrowright:'d' };
+    const mk = map[k] || k;
+    if (keys[mk]) delete keys[mk];
   });
 
   canvas.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- support arrow keys alongside WASD for camera movement
- add +/- zoom controls and `f` key for fullscreen toggle
- document new camera controls

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689db9b3607c8327b5a8053e8c76fb72