### PR TITLE
Add basic utility tests and test script

### DIFF
--- a/tilearmy/package.json
+++ b/tilearmy/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "test": "node --test"
+  },
   "dependencies": {
     "express": "^5.1.0",
     "ws": "^8.18.3"

--- a/tilearmy/server.js
+++ b/tilearmy/server.js
@@ -8,6 +8,7 @@ const express = require('express');
 const http = require('http');
 const WebSocket = require('ws');
 const path = require('path');
+const { rand, newId, clamp } = require('./utils');
 
 // ------------------ CONFIG ------------------
 const CFG = {
@@ -38,9 +39,6 @@ const players = Object.create(null); // { id: { base, vehicles, color, ore, lumb
 const resources = []; // [{id,type,x,y,amount}]
 let seeded = false;
 
-function rand(min, max){ return Math.random() * (max - min) + min; }
-function newId(len=9){ return Math.random().toString(36).slice(2, 2+len); }
-function clamp(v, lo, hi){ return Math.max(lo, Math.min(hi, v)); }
 
 function seedResources(){
   if (seeded) return;

--- a/tilearmy/test/utils.test.js
+++ b/tilearmy/test/utils.test.js
@@ -1,0 +1,21 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { rand, newId, clamp } = require('../utils');
+
+test('clamp limits numbers within range', () => {
+  assert.strictEqual(clamp(5, 0, 10), 5);
+  assert.strictEqual(clamp(-5, 0, 10), 0);
+  assert.strictEqual(clamp(15, 0, 10), 10);
+});
+
+test('newId creates string of requested length', () => {
+  assert.strictEqual(newId().length, 9);
+  assert.strictEqual(newId(5).length, 5);
+});
+
+test('rand generates number within range', () => {
+  for (let i = 0; i < 100; i++) {
+    const n = rand(5, 10);
+    assert.ok(n >= 5 && n < 10);
+  }
+});

--- a/tilearmy/utils.js
+++ b/tilearmy/utils.js
@@ -1,0 +1,13 @@
+function rand(min, max) {
+  return Math.random() * (max - min) + min;
+}
+
+function newId(len = 9) {
+  return Math.random().toString(36).slice(2, 2 + len);
+}
+
+function clamp(v, lo, hi) {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+module.exports = { rand, newId, clamp };


### PR DESCRIPTION
## Summary
- export shared helper functions to new `utils.js`
- add Node test script and tests for helper functions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dc6a3f3cc8327a711ad5258e7b184