### PR TITLE
Expand game viewport and simplify sidebar

### DIFF
--- a/tilearmy/public/client.js
+++ b/tilearmy/public/client.js
@@ -10,6 +10,15 @@
 
   const canvas = document.getElementById('game');
   const ctx = canvas.getContext('2d');
+  const mapWrap = document.getElementById('mapWrap');
+  const header = document.querySelector('header');
+  function resizeCanvas(){
+    canvas.width = mapWrap.clientWidth;
+    const h = window.innerHeight - header.offsetHeight - 40;
+    canvas.height = h > 0 ? h : 0;
+  }
+  window.addEventListener('resize', resizeCanvas);
+  resizeCanvas();
   ctx.imageSmoothingEnabled = false;
   const vehiclesDiv = document.getElementById('vehicles');
   const pidEl = document.getElementById('pid');

--- a/tilearmy/public/index.html
+++ b/tilearmy/public/index.html
@@ -9,13 +9,13 @@
     *{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--text);font:14px/1.3 system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
     header{padding:10px 16px;background:linear-gradient(180deg,#171c3b,#121632);position:sticky;top:0;z-index:10;display:flex;gap:12px;align-items:center;flex-wrap:wrap}
     h1{margin:0;font-size:16px;letter-spacing:.6px}
-    #wrap{display:grid;grid-template-columns:1fr 320px;gap:10px;padding:10px}
+    #wrap{display:grid;grid-template-columns:1fr 200px;gap:10px;padding:10px}
     #mapWrap{position:relative}
-    #game{display:block;width:100%;height:auto;max-height:70vh;aspect-ratio:1000/700;border-radius:16px;background:#0e1433;box-shadow:0 8px 30px rgba(0,0,0,.35)}
+    #game{display:block;width:100%;height:100%;border-radius:16px;background:#0e1433;box-shadow:0 8px 30px rgba(0,0,0,.35)}
     #cursorInfo{position:absolute;bottom:6px;left:6px;background:#222951;color:#b8c1ff;padding:3px 8px;border-radius:12px;font-size:12px;pointer-events:none}
     #panel{background:var(--panel);border-radius:16px;padding:12px;display:flex;flex-direction:column;gap:10px;box-shadow:0 8px 30px rgba(0,0,0,.35)}
     #panel h2{font-size:14px;margin:0 0 4px 0;color:var(--muted)}
-    #vehicles{display:grid;grid-template-columns:repeat(2,1fr);gap:6px;align-content:start;max-height:42vh;overflow:auto}
+    #vehicles{display:grid;grid-template-columns:1fr;gap:6px;align-content:start;overflow:auto}
     button{border:0;padding:8px 10px;border-radius:12px;background:#2a2f5e;color:#e8eaf6;cursor:pointer}
     button:hover{filter:brightness(1.2)} .primary{background:#535bf2} .selected{outline:2px solid var(--accent)}
     .row{display:flex;gap:8px;align-items:center} .pill{padding:3px 8px;border-radius:12px;background:#222951;color:#b8c1ff;font-size:12px}
@@ -40,14 +40,12 @@
   </header>
   <div id="wrap">
     <div id="mapWrap">
-      <canvas id="game" width="1000" height="700"></canvas>
+      <canvas id="game"></canvas>
       <div id="cursorInfo"></div>
     </div>
     <aside id="panel">
       <h2>Your Vehicles</h2>
       <div id="vehicles"></div>
-      <h2>Tips</h2>
-      <div>• Use WASD to move the camera. Press H to center on your base.<br>• Toggle camera follow to manually watch any spot.<br>• Resource icons fade as they deplete. Different vehicles have different costs.</div>
     </aside>
   </div>
   <div id="toast"></div>


### PR DESCRIPTION
## Summary
- Expand canvas to fill available space and adjust sidebar to 200px
- Remove sidebar tips and show only vehicle list
- Dynamically resize game canvas based on window size

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ddd0b588c8327ab69c71b802cd6a7