### PR TITLE
Add light and heavy tank combat vehicles

### DIFF
--- a/tilearmy/README.md
+++ b/tilearmy/README.md
@@ -17,7 +17,7 @@ TileArmy is a browser-based real-time resource-gathering game built with Node.js
 ## Gameplay
 
 - **Base & Resources** – You start with a base and some ore. Additional resources (ore, lumber and stone) are scattered around the world. Your goal is to gather them.
-- **Vehicles** – Use the dashboard to spawn vehicles. Each type (scout, hauler, basic) has different speed, capacity, energy usage and cost.
+- **Vehicles** – Use the dashboard to spawn vehicles. Each type (scout, hauler, basic, light tank, heavy tank) has different speed, capacity, energy usage and cost.
 - **Automatic harvesting** – Idle vehicles automatically seek the nearest unclaimed resource. If you click a resource tile, the selected vehicle will harvest it and then automatically chain to nearby resources of the same type within a search radius before considering other resources. Once full, vehicles return to your base to unload.
 - **Manual commands** – Click on the map to move the selected vehicle. Use the dropdown to spawn different vehicle types.
 - **Energy** – Movement consumes energy. Your energy reserve slowly regenerates over time.

--- a/tilearmy/assets/32/icon-vehicle-heavy-tank.svg
+++ b/tilearmy/assets/32/icon-vehicle-heavy-tank.svg
@@ -1,0 +1,31 @@
+<svg width="32" height="32" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <style>
+    :root{
+      --team:#22c55e;
+      --stroke:#0f172a;
+      --iron:#64748b;
+      --wood:#b45309;
+      --stone:#94a3b8;
+      --accent:#f59e0b;
+      --glass:#cbd5e1;
+    }
+    .stroke{stroke:var(--stroke); stroke-width:2; stroke-linecap:round; stroke-linejoin:round;}
+    .fill-team{fill:var(--team)}
+    .fill-iron{fill:var(--iron)}
+    .fill-wood{fill:var(--wood)}
+    .fill-stone{fill:var(--stone)}
+    .fill-accent{fill:var(--accent)}
+    .fill-glass{fill:var(--glass)}
+    .no-fill{fill:none}
+  </style>
+  <!-- tracks -->
+  <rect class="stroke fill-iron" x="10" y="40" width="44" height="10" rx="2"/>
+  <!-- hull -->
+  <rect class="stroke fill-team" x="12" y="26" width="40" height="16" rx="3"/>
+  <!-- turret -->
+  <rect class="stroke fill-team" x="24" y="18" width="16" height="10" rx="2"/>
+  <!-- barrel -->
+  <path class="stroke" d="M40 23 H56"/>
+  <!-- hatch -->
+  <circle class="stroke fill-accent" cx="32" cy="23" r="2"/>
+</svg>

--- a/tilearmy/assets/32/icon-vehicle-light-tank.svg
+++ b/tilearmy/assets/32/icon-vehicle-light-tank.svg
@@ -1,0 +1,29 @@
+<svg width="32" height="32" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <style>
+    :root{
+      --team:#22c55e;
+      --stroke:#0f172a;
+      --iron:#64748b;
+      --wood:#b45309;
+      --stone:#94a3b8;
+      --accent:#f59e0b;
+      --glass:#cbd5e1;
+    }
+    .stroke{stroke:var(--stroke); stroke-width:2; stroke-linecap:round; stroke-linejoin:round;}
+    .fill-team{fill:var(--team)}
+    .fill-iron{fill:var(--iron)}
+    .fill-wood{fill:var(--wood)}
+    .fill-stone{fill:var(--stone)}
+    .fill-accent{fill:var(--accent)}
+    .fill-glass{fill:var(--glass)}
+    .no-fill{fill:none}
+  </style>
+  <!-- tracks -->
+  <rect class="stroke fill-iron" x="12" y="42" width="40" height="8" rx="2"/>
+  <!-- hull -->
+  <rect class="stroke fill-team" x="14" y="30" width="36" height="14" rx="2"/>
+  <!-- turret -->
+  <rect class="stroke fill-team" x="26" y="24" width="12" height="8" rx="2"/>
+  <!-- barrel -->
+  <path class="stroke" d="M38 28 H52"/>
+</svg>

--- a/tilearmy/assets/48/icon-vehicle-heavy-tank.svg
+++ b/tilearmy/assets/48/icon-vehicle-heavy-tank.svg
@@ -1,0 +1,31 @@
+<svg width="48" height="48" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <style>
+    :root{
+      --team:#22c55e;
+      --stroke:#0f172a;
+      --iron:#64748b;
+      --wood:#b45309;
+      --stone:#94a3b8;
+      --accent:#f59e0b;
+      --glass:#cbd5e1;
+    }
+    .stroke{stroke:var(--stroke); stroke-width:2; stroke-linecap:round; stroke-linejoin:round;}
+    .fill-team{fill:var(--team)}
+    .fill-iron{fill:var(--iron)}
+    .fill-wood{fill:var(--wood)}
+    .fill-stone{fill:var(--stone)}
+    .fill-accent{fill:var(--accent)}
+    .fill-glass{fill:var(--glass)}
+    .no-fill{fill:none}
+  </style>
+  <!-- tracks -->
+  <rect class="stroke fill-iron" x="10" y="40" width="44" height="10" rx="2"/>
+  <!-- hull -->
+  <rect class="stroke fill-team" x="12" y="26" width="40" height="16" rx="3"/>
+  <!-- turret -->
+  <rect class="stroke fill-team" x="24" y="18" width="16" height="10" rx="2"/>
+  <!-- barrel -->
+  <path class="stroke" d="M40 23 H56"/>
+  <!-- hatch -->
+  <circle class="stroke fill-accent" cx="32" cy="23" r="2"/>
+</svg>

--- a/tilearmy/assets/48/icon-vehicle-light-tank.svg
+++ b/tilearmy/assets/48/icon-vehicle-light-tank.svg
@@ -1,0 +1,29 @@
+<svg width="48" height="48" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <style>
+    :root{
+      --team:#22c55e;
+      --stroke:#0f172a;
+      --iron:#64748b;
+      --wood:#b45309;
+      --stone:#94a3b8;
+      --accent:#f59e0b;
+      --glass:#cbd5e1;
+    }
+    .stroke{stroke:var(--stroke); stroke-width:2; stroke-linecap:round; stroke-linejoin:round;}
+    .fill-team{fill:var(--team)}
+    .fill-iron{fill:var(--iron)}
+    .fill-wood{fill:var(--wood)}
+    .fill-stone{fill:var(--stone)}
+    .fill-accent{fill:var(--accent)}
+    .fill-glass{fill:var(--glass)}
+    .no-fill{fill:none}
+  </style>
+  <!-- tracks -->
+  <rect class="stroke fill-iron" x="12" y="42" width="40" height="8" rx="2"/>
+  <!-- hull -->
+  <rect class="stroke fill-team" x="14" y="30" width="36" height="14" rx="2"/>
+  <!-- turret -->
+  <rect class="stroke fill-team" x="26" y="24" width="12" height="8" rx="2"/>
+  <!-- barrel -->
+  <path class="stroke" d="M38 28 H52"/>
+</svg>

--- a/tilearmy/assets/icon-vehicle-heavy-tank.svg
+++ b/tilearmy/assets/icon-vehicle-heavy-tank.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <style>
+    :root{
+      --team:#22c55e;
+      --stroke:#0f172a;
+      --iron:#64748b;
+      --wood:#b45309;
+      --stone:#94a3b8;
+      --accent:#f59e0b;
+      --glass:#cbd5e1;
+    }
+    .stroke{stroke:var(--stroke); stroke-width:2; stroke-linecap:round; stroke-linejoin:round;}
+    .fill-team{fill:var(--team)}
+    .fill-iron{fill:var(--iron)}
+    .fill-wood{fill:var(--wood)}
+    .fill-stone{fill:var(--stone)}
+    .fill-accent{fill:var(--accent)}
+    .fill-glass{fill:var(--glass)}
+    .no-fill{fill:none}
+  </style>
+  <!-- tracks -->
+  <rect class="stroke fill-iron" x="10" y="40" width="44" height="10" rx="2"/>
+  <!-- hull -->
+  <rect class="stroke fill-team" x="12" y="26" width="40" height="16" rx="3"/>
+  <!-- turret -->
+  <rect class="stroke fill-team" x="24" y="18" width="16" height="10" rx="2"/>
+  <!-- barrel -->
+  <path class="stroke" d="M40 23 H56"/>
+  <!-- hatch -->
+  <circle class="stroke fill-accent" cx="32" cy="23" r="2"/>
+</svg>

--- a/tilearmy/assets/icon-vehicle-light-tank.svg
+++ b/tilearmy/assets/icon-vehicle-light-tank.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <style>
+    :root{
+      --team:#22c55e;
+      --stroke:#0f172a;
+      --iron:#64748b;
+      --wood:#b45309;
+      --stone:#94a3b8;
+      --accent:#f59e0b;
+      --glass:#cbd5e1;
+    }
+    .stroke{stroke:var(--stroke); stroke-width:2; stroke-linecap:round; stroke-linejoin:round;}
+    .fill-team{fill:var(--team)}
+    .fill-iron{fill:var(--iron)}
+    .fill-wood{fill:var(--wood)}
+    .fill-stone{fill:var(--stone)}
+    .fill-accent{fill:var(--accent)}
+    .fill-glass{fill:var(--glass)}
+    .no-fill{fill:none}
+  </style>
+  <!-- tracks -->
+  <rect class="stroke fill-iron" x="12" y="42" width="40" height="8" rx="2"/>
+  <!-- hull -->
+  <rect class="stroke fill-team" x="14" y="30" width="36" height="14" rx="2"/>
+  <!-- turret -->
+  <rect class="stroke fill-team" x="26" y="24" width="12" height="8" rx="2"/>
+  <!-- barrel -->
+  <path class="stroke" d="M38 28 H52"/>
+</svg>

--- a/tilearmy/public/client.js
+++ b/tilearmy/public/client.js
@@ -40,7 +40,9 @@
       'icon-home-base',
       'icon-vehicle-scout',
       'icon-vehicle-hauler',
-      'icon-vehicle-hummer'
+      'icon-vehicle-hummer',
+      'icon-vehicle-light-tank',
+      'icon-vehicle-heavy-tank'
     ];
     const svgs = {};
     const dir = size === 64 ? '' : size + '/';
@@ -80,6 +82,8 @@
         scout: vehicleSheet.makeImg('icon-vehicle-scout', color),
         hauler: vehicleSheet.makeImg('icon-vehicle-hauler', color),
         basic: vehicleSheet.makeImg('icon-vehicle-hummer', color),
+        lightTank: vehicleSheet.makeImg('icon-vehicle-light-tank', color),
+        heavyTank: vehicleSheet.makeImg('icon-vehicle-heavy-tank', color),
       };
     }
     return teamIcons[pid];


### PR DESCRIPTION
## Summary
- Introduce new light and heavy tank vehicle types
- Add SVG icons for light and heavy tanks in all icon sizes
- Prevent non-harvesting vehicles from auto-extracting resources

## Testing
- `cd tilearmy && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ef1f7d5508327a7bcd74839327fa3