### PR TITLE
Add touch-friendly bookmark control

### DIFF
--- a/tilearmy/README.md
+++ b/tilearmy/README.md
@@ -22,6 +22,7 @@ TileArmy is a browser-based real-time resource-gathering game built with Node.js
 - **Manual commands** – Click on the map to move the selected vehicle. Use the dropdown to spawn different vehicle types.
 - **Energy** – Movement consumes energy. Your energy reserve slowly regenerates over time.
 - **Camera** – Toggle the "Follow" button to keep the view centered on your selected vehicle, or use WASD/arrow keys to pan manually. Use `+`/`-` to zoom, `F` to toggle fullscreen, and press `H` to jump back to your base.
+- **Bookmarks** – Shift-click on the map or tap **Add Bookmark** then tap the map to save locations for quick navigation from the sidebar.
 - **Map coordinates** – The cursor panel shows tile coordinates and distance. The server configures the tile size (default 32), so tile `(2,3)` appears at pixel position `(64,96)`.
 
 Happy harvesting!

--- a/tilearmy/public/client.js
+++ b/tilearmy/public/client.js
@@ -33,6 +33,7 @@
   const toast = document.getElementById('toast');
   const vTypeSel = document.getElementById('vehicleType');
   const cursorInfo = document.getElementById('cursorInfo');
+  const addBookmarkBtn = document.getElementById('addBookmark');
 
   // Load individual SVG icons and prepare helpers
   async function loadIconSheet(size){
@@ -103,6 +104,7 @@
   const bullets = [];
   const fireTimers = Object.create(null);
   const bookmarks = [];
+  let bookmarkMode = false;
   const VEHICLE_OFFSETS = { scout: Math.PI/2 };
   const getBase = id => state.bases.find(b=>b.id===id);
 
@@ -122,6 +124,10 @@
   document.getElementById('toggleFollow').onclick = () => {
     camera.follow = !camera.follow;
     document.getElementById('toggleFollow').textContent = 'Follow: ' + (camera.follow ? 'On' : 'Off');
+  };
+  addBookmarkBtn.onclick = () => {
+    bookmarkMode = true;
+    showToast('Tap map to add bookmark');
   };
 
   function focusOn(x,y,instant){
@@ -352,7 +358,7 @@
     const sx = (e.clientX - r.left) * (canvas.width / r.width);
     const sy = (e.clientY - r.top) * (canvas.height / r.height);
     const w = toWorld(sx, sy);
-    if (e.shiftKey){
+    if (e.shiftKey || bookmarkMode){
       const bm = { x: w.x, y: w.y };
       const baseHit = state.bases.find(b => Math.hypot(b.x - w.x, b.y - w.y) <= (cfg.BASE_ICON_SIZE/2));
       if (baseHit){
@@ -379,6 +385,7 @@
       }
       bookmarks.push(bm);
       rebuildDashboard();
+      bookmarkMode = false;
       e.preventDefault();
       return;
     }

--- a/tilearmy/public/index.html
+++ b/tilearmy/public/index.html
@@ -34,6 +34,7 @@
       <select id="vehicleType" style="display:none"></select>
       <button id="spawn" class="primary" style="display:none">Spawn Vehicle</button>
       <button id="toggleFollow">Follow: On</button>
+      <button id="addBookmark">Add Bookmark</button>
       <span id="pid" class="pill"></span>
       <div id="stats" class="pill">Ore: <span id="oreCount">0</span> | Lumber: <span id="lumberCount">0</span> | Stone: <span id="stoneCount">0</span></div>
       <div id="energyBar"><div id="energyFill"></div></div>


### PR DESCRIPTION
## Summary
- add Add Bookmark button to header for devices without shift key
- allow toggling bookmark mode so next map tap saves a bookmark
- document bookmark feature in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f3fb4c7848327afe3b8b4bc443c12