### PR TITLE
Reduce client CPU usage for game

### DIFF
--- a/tilearmy/public/client.js
+++ b/tilearmy/public/client.js
@@ -712,9 +712,24 @@
     }
   }
 
+  const FPS = 30; // limit rendering to reduce CPU usage
+  const FRAME_MS = 1000 / FPS;
   let lastTime = performance.now();
+  let lastFrame = performance.now();
   function draw(now){
-    const dt = (now - lastTime) / 1000; lastTime = now;
+    if (document.hidden){
+      lastTime = now;
+      lastFrame = now;
+      requestAnimationFrame(draw);
+      return;
+    }
+    const dt = (now - lastTime) / 1000;
+    if (now - lastFrame < FRAME_MS){
+      requestAnimationFrame(draw);
+      return;
+    }
+    lastTime = now;
+    lastFrame = now;
     ctx.clearRect(0,0,canvas.width,canvas.height);
     updateCamera(dt);
     smoothVehiclePositions();


### PR DESCRIPTION
## Summary
- throttle client rendering to 30 FPS and pause rendering when tab is hidden

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fd1d087608327854257f243b2c923