### PR TITLE
Fix scout orientation when moving left

### DIFF
--- a/tilearmy/public/client.js
+++ b/tilearmy/public/client.js
@@ -656,8 +656,8 @@
         const offset = VEHICLE_OFFSETS[v.type] || 0;
         ctx.save();
         ctx.translate(vx, vy);
-        ctx.rotate(ang + offset);
         if (flip) ctx.scale(-1,1);
+        ctx.rotate(ang + offset);
         ctx.drawImage(img, -size/2, -size/2, size, size);
         ctx.restore();
         const maxHp = (state.cfg.VEHICLE_TYPES[v.type]||{}).hp || 1;


### PR DESCRIPTION
## Summary
- flip scout sprites before rotation so they face correctly when traveling left

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fdee0d58c83278d46b7a228e807d0