### PR TITLE
feat: add map scaling and dynamic base seeding

### DIFF
--- a/tilearmy/README.md
+++ b/tilearmy/README.md
@@ -14,6 +14,20 @@ TileArmy is a browser-based real-time resource-gathering game built with Node.js
    ```
 3. Open [http://localhost:3000](http://localhost:3000) in your browser.
 
+## Configuration
+
+You can tweak gameplay by setting environment variables before starting the server:
+
+- `MAPSIZE` – scales map dimensions from the base 4000×3000. A value of `10` results in a 40000×30000 world. Default: `10`.
+- `PLENTIFUL` – controls how many resource nodes spawn. Higher values mean more resources. Default: `4`.
+- `CROWD` – number of neutral bases spawned each time a player joins. Default: `3`.
+
+Example:
+
+```bash
+MAPSIZE=5 PLENTIFUL=2 CROWD=1 node server.js
+```
+
 ## Gameplay
 
 - **Base & Resources** – You start with a base and some ore. Additional resources (ore, lumber and stone) are scattered around the world. Your goal is to gather them.


### PR DESCRIPTION
## Summary
- introduce MAPSIZE, PLENTIFUL and CROWD environment variables for map scale, resource density and neutral base frequency
- spawn new neutral bases for each player connection
- document new configuration options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0180d6f288327b868edeb3acf2b62