### PR TITLE
Show player names on hover and in bookmarks

### DIFF
--- a/tilearmy/public/client.js
+++ b/tilearmy/public/client.js
@@ -178,7 +178,7 @@
     const myBases = state.bases.filter(b=>b.owner===myId);
     myBases.forEach(b => {
       const btn = document.createElement('button');
-      btn.textContent = b.id;
+      btn.textContent = b.name || b.id;
       if (selected && selected.type==='base' && selected.id === b.id) btn.classList.add('selected');
       btn.onclick = () => { selected = {type:'base', id:b.id}; rebuildDashboard(); updateCursorInfo(); updateSpawnControls(); };
       basesDiv.appendChild(btn);
@@ -199,7 +199,12 @@
       const x = Math.floor(bm.x / tile);
       const y = Math.floor(bm.y / tile);
       const span = document.createElement('span');
-      span.textContent = x + ',' + y;
+      let label = x + ',' + y;
+      if (bm.entity && bm.entity.type === 'base'){
+        const base = getBase(bm.entity.id);
+        if (base && base.name) label = base.name;
+      }
+      span.textContent = label;
       btn.appendChild(span);
 
       if (bm.entity){
@@ -310,6 +315,13 @@
     const x = Math.floor(w.x / tile);
     const y = Math.floor(w.y / tile);
     let text = `${x}, ${y}`;
+    const baseHover = findBaseAt(w.x, w.y);
+    if (baseHover){
+      text += ` | ${baseHover.owner || 'neutral'}`;
+    } else {
+      const vInfo = findVehicleAt(w.x, w.y);
+      if (vInfo){ text += ` | ${vInfo.pid}`; }
+    }
     const me = state.players[myId];
     if (me){
       let ox, oy;

--- a/tilearmy/server.js
+++ b/tilearmy/server.js
@@ -163,7 +163,8 @@ wss.on('connection', (ws, req) => {
       hp: CFG.BASE_HP,
       damage: CFG.BASE_DAMAGE,
       rof: CFG.BASE_ROF,
-      queue: []
+      queue: [],
+      name: `${id} Home`
     };
     bases.push(base);
     spawnNeutralBases(CFG.CROWD);
@@ -275,9 +276,11 @@ function resolveCaptures(){
       }
       if (players[att]){
         if (!players[att].bases.includes(b.id)) players[att].bases.push(b.id);
+        const idx = players[att].bases.indexOf(b.id);
+        b.name = idx === 0 ? `${att} Home` : `${att} Base ${idx}`;
         const ws = connections[att];
         if (ws && ws.readyState === WebSocket.OPEN){
-          ws.send(JSON.stringify({ type: 'notice', ok: true, msg: `Congratulations, you have conquered base ${b.id}!` }));
+          ws.send(JSON.stringify({ type: 'notice', ok: true, msg: `Congratulations, you have conquered base ${b.name}!` }));
         }
       }
       delete b.lastAttacker;

--- a/tilearmy/test/combat.test.js
+++ b/tilearmy/test/combat.test.js
@@ -10,7 +10,7 @@ function resetState(){
 
 test('base captured after HP reaches zero', () => {
   resetState();
-  players.attacker = { bases: [], vehicles: [] };
+  players.attacker = { bases: ['h0'], vehicles: [] };
   players.defender = { bases: ['b1'], vehicles: [] };
   const base = { id: 'b1', x: 0, y: 0, owner: 'defender', hp: 0, damage: CFG.NEUTRAL_BASE_DAMAGE, rof: CFG.NEUTRAL_BASE_ROF, queue: [], lastAttacker: 'attacker' };
   bases.push(base);
@@ -19,6 +19,7 @@ test('base captured after HP reaches zero', () => {
 
   assert.strictEqual(base.owner, 'attacker');
   assert.strictEqual(base.hp, CFG.BASE_HP);
+  assert.strictEqual(base.name, 'attacker Base 1');
   assert.deepStrictEqual(players.defender.bases, []);
   assert.ok(players.attacker.bases.includes('b1'));
 });


### PR DESCRIPTION
## Summary
- Name home bases and conquered bases after their owner
- Display owner names when hovering bases or vehicles
- Show base names in the base list and bookmarks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a01fd0f5088327b56aceb05cfde14c