### PR TITLE
Rotate scout icon to face right

### DIFF
--- a/tilearmy/assets/32/icon-vehicle-scout.svg
+++ b/tilearmy/assets/32/icon-vehicle-scout.svg
@@ -18,15 +18,17 @@
     .fill-glass{fill:var(--glass)}
     .no-fill{fill:none}
   </style>
-  <!-- body -->
-  <path class="stroke fill-team" d="M24 44 L32 18 L40 44 Z"/>
-  <!-- cockpit window -->
-  <polygon class="stroke fill-glass" points="32 22, 36 36, 28 36"/>
-  <!-- wheels -->
-  <circle class="stroke" cx="22" cy="46" r="4" fill="#111827"/>
-  <circle class="stroke" cx="42" cy="46" r="4" fill="#111827"/>
-  <!-- antenna -->
-  <path class="stroke" d="M32 18 L32 12"/>
-  <circle class="stroke fill-accent" cx="32" cy="11" r="1.8"/>
+  <g transform="rotate(90 32 32)">
+    <!-- body -->
+    <path class="stroke fill-team" d="M24 44 L32 18 L40 44 Z"/>
+    <!-- cockpit window -->
+    <polygon class="stroke fill-glass" points="32 22, 36 36, 28 36"/>
+    <!-- wheels -->
+    <circle class="stroke" cx="22" cy="46" r="4" fill="#111827"/>
+    <circle class="stroke" cx="42" cy="46" r="4" fill="#111827"/>
+    <!-- antenna -->
+    <path class="stroke" d="M32 18 L32 12"/>
+    <circle class="stroke fill-accent" cx="32" cy="11" r="1.8"/>
+  </g>
 </svg>
 

--- a/tilearmy/assets/48/icon-vehicle-scout.svg
+++ b/tilearmy/assets/48/icon-vehicle-scout.svg
@@ -18,15 +18,17 @@
     .fill-glass{fill:var(--glass)}
     .no-fill{fill:none}
   </style>
-  <!-- body -->
-  <path class="stroke fill-team" d="M24 44 L32 18 L40 44 Z"/>
-  <!-- cockpit window -->
-  <polygon class="stroke fill-glass" points="32 22, 36 36, 28 36"/>
-  <!-- wheels -->
-  <circle class="stroke" cx="22" cy="46" r="4" fill="#111827"/>
-  <circle class="stroke" cx="42" cy="46" r="4" fill="#111827"/>
-  <!-- antenna -->
-  <path class="stroke" d="M32 18 L32 12"/>
-  <circle class="stroke fill-accent" cx="32" cy="11" r="1.8"/>
+  <g transform="rotate(90 32 32)">
+    <!-- body -->
+    <path class="stroke fill-team" d="M24 44 L32 18 L40 44 Z"/>
+    <!-- cockpit window -->
+    <polygon class="stroke fill-glass" points="32 22, 36 36, 28 36"/>
+    <!-- wheels -->
+    <circle class="stroke" cx="22" cy="46" r="4" fill="#111827"/>
+    <circle class="stroke" cx="42" cy="46" r="4" fill="#111827"/>
+    <!-- antenna -->
+    <path class="stroke" d="M32 18 L32 12"/>
+    <circle class="stroke fill-accent" cx="32" cy="11" r="1.8"/>
+  </g>
 </svg>
 

--- a/tilearmy/assets/icon-vehicle-scout.svg
+++ b/tilearmy/assets/icon-vehicle-scout.svg
@@ -18,15 +18,17 @@
     .fill-glass{fill:var(--glass)}
     .no-fill{fill:none}
   </style>
-  <!-- body -->
-  <path class="stroke fill-team" d="M24 44 L32 18 L40 44 Z"/>
-  <!-- cockpit window -->
-  <polygon class="stroke fill-glass" points="32 22, 36 36, 28 36"/>
-  <!-- wheels -->
-  <circle class="stroke" cx="22" cy="46" r="4" fill="#111827"/>
-  <circle class="stroke" cx="42" cy="46" r="4" fill="#111827"/>
-  <!-- antenna -->
-  <path class="stroke" d="M32 18 L32 12"/>
-  <circle class="stroke fill-accent" cx="32" cy="11" r="1.8"/>
+  <g transform="rotate(90 32 32)">
+    <!-- body -->
+    <path class="stroke fill-team" d="M24 44 L32 18 L40 44 Z"/>
+    <!-- cockpit window -->
+    <polygon class="stroke fill-glass" points="32 22, 36 36, 28 36"/>
+    <!-- wheels -->
+    <circle class="stroke" cx="22" cy="46" r="4" fill="#111827"/>
+    <circle class="stroke" cx="42" cy="46" r="4" fill="#111827"/>
+    <!-- antenna -->
+    <path class="stroke" d="M32 18 L32 12"/>
+    <circle class="stroke fill-accent" cx="32" cy="11" r="1.8"/>
+  </g>
 </svg>
 

--- a/tilearmy/public/client.js
+++ b/tilearmy/public/client.js
@@ -115,7 +115,6 @@
   const fireTimers = Object.create(null);
   const bookmarks = [];
   let bookmarkMode = false;
-  const VEHICLE_OFFSETS = { scout: Math.PI/2 };
   const getBase = id => state.bases.find(b=>b.id===id);
   const findBaseAt = (x, y) => state.bases.find(b => Math.hypot(b.x - x, b.y - y) <= (cfg.BASE_ICON_SIZE/2));
   function findVehicleAt(x, y){
@@ -719,10 +718,9 @@
         let ang = rv.angle || 0;
         let flip = false;
         if (ang > Math.PI/2 || ang < -Math.PI/2){ flip = true; }
-        const offset = VEHICLE_OFFSETS[v.type] || 0;
         ctx.save();
         ctx.translate(vx, vy);
-        ctx.rotate(ang + offset);
+        ctx.rotate(ang);
         if (flip) ctx.scale(1,-1);
         ctx.drawImage(img, -size/2, -size/2, size, size);
         ctx.restore();


### PR DESCRIPTION
## Summary
- rotate scout vehicle icons 90° so they face right like other vehicles
- drop special scout rotation offset and draw vehicles using their angle only

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a01ff92c04832796d84b0b561f712d