### PR TITLE
Dock offline players' vehicles after timeout

### DIFF
--- a/tilearmy/server.js
+++ b/tilearmy/server.js
@@ -37,6 +37,7 @@ const CFG = {
   HARVEST_RATE: 40,          // units/sec
   ENERGY_MAX: 100,           // player energy cap
   ENERGY_RECHARGE: 15,       // energy/sec auto recharge
+  OFFLINE_TIMEOUT: parseInt(process.env.OFFLINE_TIMEOUT_MS, 10) || 2 * 60 * 1000, // ms before offline players dock
   UNLOAD_TIME: 1000,         // ms to unload at base
   BASE_ATTACK_RANGE: 150,
   BASE_HP: 200,
@@ -174,10 +175,14 @@ wss.on('connection', (ws, req) => {
       ore: 2000, // start with some ore
       lumber: 0,
       stone: 0,
-      energy: CFG.ENERGY_MAX
+      energy: CFG.ENERGY_MAX,
+      disconnectedAt: null,
+      offline: false
     };
   }
 
+  players[id].disconnectedAt = null;
+  players[id].offline = false;
   connections[id] = ws;
 
   ws.send(JSON.stringify({ type: 'init', id, state: snapshotState() }));
@@ -225,6 +230,7 @@ wss.on('connection', (ws, req) => {
   ws.on('close', () => {
     // Keep player state so they can reconnect later; just remove the socket
     if (connections[id] === ws) delete connections[id];
+    if (players[id]) players[id].disconnectedAt = Date.now();
   });
 });
 
@@ -307,11 +313,29 @@ function gameLoop(){
 
   for (const pid in players){
     const pl = players[pid];
+    if (pl.disconnectedAt && now - pl.disconnectedAt >= CFG.OFFLINE_TIMEOUT) {
+      pl.offline = true;
+    }
+
     let energySpent = 0;
 
     for (const v of pl.vehicles){
+      if (pl.offline){
+        const b = nearestBase(pl, v.x, v.y);
+        if (b){
+          const dist = Math.hypot(b.x - v.x, b.y - v.y);
+          if (dist > 30 && v.state !== 'returning' && v.state !== 'unloading'){
+            v.state = 'returning';
+            v.targetRes = null;
+            v.tx = b.x;
+            v.ty = b.y;
+            v.targetBase = b.id;
+          }
+        }
+      }
+
       // Auto-target resources
-      if (v.capacity > 0 && v.state === 'idle' && v.carrying < v.capacity){
+      if (!pl.offline && v.capacity > 0 && v.state === 'idle' && v.carrying < v.capacity){
         if (!v.targetRes || !resources.find(r => r.id===v.targetRes && r.amount>0)){
           let best=null, bd=Infinity;
           const consider = (type, radius) => {
@@ -450,4 +474,4 @@ if (process.env.NODE_ENV !== 'test'){
   server.listen(PORT, () => console.log(`TileArmy server running: http://localhost:${PORT}`));
 }
 
-module.exports = { CFG, players, bases, processManufacturing, resolveCaptures, gameLoop };
+module.exports = { CFG, players, bases, resources, processManufacturing, resolveCaptures, gameLoop };

--- a/tilearmy/test/combat.test.js
+++ b/tilearmy/test/combat.test.js
@@ -1,10 +1,11 @@
 process.env.NODE_ENV = 'test';
 const test = require('node:test');
 const assert = require('node:assert');
-const { CFG, players, bases, processManufacturing, resolveCaptures } = require('../server');
+const { CFG, players, bases, resources, processManufacturing, resolveCaptures } = require('../server');
 
 function resetState(){
   bases.length = 0;
+  resources.length = 0;
   for (const k of Object.keys(players)) delete players[k];
 }
 

--- a/tilearmy/test/offline.test.js
+++ b/tilearmy/test/offline.test.js
@@ -1,0 +1,45 @@
+process.env.NODE_ENV = 'test';
+process.env.OFFLINE_TIMEOUT_MS = 100;
+const test = require('node:test');
+const assert = require('node:assert');
+const { CFG, players, bases, resources, gameLoop } = require('../server');
+
+function resetState(){
+  bases.length = 0;
+  resources.length = 0;
+  for (const k of Object.keys(players)) delete players[k];
+}
+
+test('vehicles dock and stop harvesting after offline timeout', () => {
+  resetState();
+  players.p1 = { bases: ['b1'], vehicles: [], ore: 0, lumber: 0, stone: 0, energy: CFG.ENERGY_MAX, disconnectedAt: Date.now() - CFG.OFFLINE_TIMEOUT - 10, offline: false };
+  const base = { id: 'b1', x: 0, y: 0, owner: 'p1', hp: CFG.BASE_HP, damage: CFG.BASE_DAMAGE, rof: CFG.BASE_ROF, queue: [] };
+  bases.push(base);
+  const vehicle = {
+    id: 'v1', type: 'basic', speed: 1000, capacity: 100, energyCost: 0, hp: 100, damage: 0, rof: 0,
+    x: 100, y: 0, tx: 100, ty: 0,
+    carrying: 50, carryType: 'ore',
+    state: 'idle', targetRes: null, targetBase: null, unloadTimer: 0
+  };
+  players.p1.vehicles.push(vehicle);
+
+  // Trigger offline docking
+  gameLoop();
+  assert.strictEqual(vehicle.state, 'returning');
+  assert.strictEqual(vehicle.targetRes, null);
+
+  // Let vehicle reach base and unload
+  for (let i = 0; i < 40; i++) gameLoop();
+  assert.strictEqual(vehicle.state, 'idle');
+  assert.ok(Math.hypot(vehicle.x - base.x, vehicle.y - base.y) < 1);
+  assert.strictEqual(vehicle.carrying, 0);
+  assert.strictEqual(players.p1.ore, 50);
+
+  // Ensure no harvesting while offline
+  resources.push({ id: 'r1', type: 'ore', x: 0, y: 0, amount: 1000 });
+  const oreBefore = players.p1.ore;
+  for (let i = 0; i < 20; i++) gameLoop();
+  assert.strictEqual(vehicle.state, 'idle');
+  assert.strictEqual(players.p1.ore, oreBefore);
+  assert.strictEqual(resources[0].amount, 1000);
+});

--- a/tilearmy/test/unload.test.js
+++ b/tilearmy/test/unload.test.js
@@ -1,10 +1,11 @@
 process.env.NODE_ENV = 'test';
 const test = require('node:test');
 const assert = require('node:assert');
-const { CFG, players, bases, gameLoop } = require('../server');
+const { CFG, players, bases, resources, gameLoop } = require('../server');
 
 function resetState(){
   bases.length = 0;
+  resources.length = 0;
   for (const k of Object.keys(players)) delete players[k];
 }
 


### PR DESCRIPTION
## Summary
- add configurable `OFFLINE_TIMEOUT` to stop harvesting after 2m offline
- send disconnected players' vehicles back to base and halt auto-harvest
- test vehicle docking when a player remains offline

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0206d32408327b2e1d08ee992a502