### PR TITLE
Add base upgrade mechanics

### DIFF
--- a/tilearmy/README.md
+++ b/tilearmy/README.md
@@ -34,6 +34,7 @@ MAPSIZE=5 PLENTIFUL=2 CROWD=1 node server.js
 
 - **Base & Resources** – You start with a base and some ore. Additional resources (ore, lumber and stone) are scattered around the world. Your goal is to gather them.
 - **Vehicles** – Use the dashboard to spawn vehicles. Each type (scout, hauler, basic, light tank, heavy tank) has different speed, capacity, energy usage and cost.
+- **Base Upgrades** – Spend lumber and stone to upgrade your bases, increasing their HP and attack power.
 - **Automatic harvesting** – Idle vehicles automatically seek the nearest unclaimed resource. If you click a resource tile, the selected vehicle will harvest it and then automatically chain to nearby resources of the same type within a search radius before considering other resources. Once full, vehicles return to your base to unload.
 - **Manual commands** – Click on the map to move the selected vehicle. Use the dropdown to spawn different vehicle types.
 - **Energy** – Movement consumes energy. Your energy reserve slowly regenerates over time.

--- a/tilearmy/public/index.html
+++ b/tilearmy/public/index.html
@@ -33,6 +33,7 @@
     <div class="row">
       <select id="vehicleType" style="display:none"></select>
       <button id="spawn" class="primary" style="display:none">Spawn Vehicle</button>
+      <button id="upgradeBase" style="display:none">Upgrade Base</button>
       <button id="toggleFollow">Follow: On</button>
       <button id="addBookmark">Add Bookmark</button>
       <span id="pid" class="pill"></span>

--- a/tilearmy/test/upgrade.test.js
+++ b/tilearmy/test/upgrade.test.js
@@ -1,0 +1,29 @@
+process.env.NODE_ENV = 'test';
+const test = require('node:test');
+const assert = require('node:assert');
+const { CFG, players, bases, upgradeBase, baseUpgradeCost } = require('../server');
+
+function resetState(){
+  bases.length = 0;
+  for (const k of Object.keys(players)) delete players[k];
+}
+
+test('upgrading a base consumes resources and boosts stats', () => {
+  resetState();
+  players.p1 = { bases: ['b1'], vehicles: [], lumber: 500, stone: 500 };
+  const base = { id: 'b1', x: 0, y: 0, owner: 'p1', level: 1, queue: [] };
+  bases.push(base);
+  // base stats before upgrade
+  base.hp = CFG.BASE_HP;
+  base.damage = CFG.BASE_DAMAGE;
+
+  const ok = upgradeBase('p1', 'b1');
+  assert.strictEqual(ok, true);
+  assert.strictEqual(base.level, 2);
+  assert.strictEqual(base.hp, CFG.BASE_HP + 100);
+  assert.strictEqual(base.damage, CFG.BASE_DAMAGE + 5);
+  const cost = baseUpgradeCost(1);
+  assert.strictEqual(players.p1.lumber, 500 - cost.lumber);
+  assert.strictEqual(players.p1.stone, 500 - cost.stone);
+});
+


### PR DESCRIPTION
## Summary
- allow bases to be upgraded for lumber and stone with increasing costs
- show base levels and upgrade controls in the client UI
- document base upgrades and add tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a02f8bece483278fb96ab24b1c24b5