### PR TITLE
Add transport vehicle and base level spawn rules

### DIFF
--- a/tilearmy/README.md
+++ b/tilearmy/README.md
@@ -33,7 +33,7 @@ MAPSIZE=5 PLENTIFUL=2 CROWD=1 node server.js
 ## Gameplay
 
 - **Base & Resources** – You start with a base and some ore. Additional resources (ore, lumber and stone) are scattered around the world. Your goal is to gather them.
-- **Vehicles** – Use the dashboard to spawn vehicles. Each type (scout, hauler, basic, light tank, heavy tank) has different speed, capacity, energy usage and cost.
+- **Vehicles** – Use the dashboard to spawn vehicles. Each type (scout, hauler, basic, light tank, heavy tank, transport) has different speed, capacity, energy usage and cost. Bases unlock vehicles by level: level 1 scouts; level 2 scouts, haulers and light tanks; level 3 basic and heavy tanks; level 4 transports.
 - **Base Upgrades** – Spend lumber and stone to upgrade your bases, increasing their HP and attack power.
 - **Automatic harvesting** – Idle vehicles automatically seek the nearest unclaimed resource. If you click a resource tile, the selected vehicle will harvest it and then automatically chain to nearby resources of the same type within a search radius before considering other resources. Once full, vehicles return to your base to unload.
 - **Manual commands** – Click on the map to move the selected vehicle. Use the dropdown to spawn different vehicle types.

--- a/tilearmy/public/client.js
+++ b/tilearmy/public/client.js
@@ -263,6 +263,7 @@
     const show = base && base.owner === myId;
     vTypeSel.style.display = show ? '' : 'none';
     document.getElementById('spawn').style.display = show ? '' : 'none';
+    if (show) refreshVehicleTypes(base); else refreshVehicleTypes(null);
     if (upgradeBtn){
       if (show){
         const lvl = base.level || 1;
@@ -273,14 +274,18 @@
     }
   }
 
-  function refreshVehicleTypes(){
+  function refreshVehicleTypes(base){
     if (!vTypeSel) return;
     vTypeSel.innerHTML = '';
     const types = state.cfg.VEHICLE_TYPES || {};
+    const allowedMap = state.cfg.BASE_LEVEL_VEHICLES || {};
+    const allowed = base ? (allowedMap[base.level || 1] || []) : Object.keys(types);
     Object.keys(types).forEach(t => {
-      const opt = document.createElement('option');
-      opt.value = t; opt.textContent = t + ` (-${types[t].cost})`;
-      vTypeSel.appendChild(opt);
+      if (!base || allowed.includes(t)){
+        const opt = document.createElement('option');
+        opt.value = t; opt.textContent = t + ` (-${types[t].cost})`;
+        vTypeSel.appendChild(opt);
+      }
     });
   }
 

--- a/tilearmy/server.js
+++ b/tilearmy/server.js
@@ -46,12 +46,19 @@ const CFG = {
   NEUTRAL_BASE_HP: 150,
   NEUTRAL_BASE_DAMAGE: 5,
   NEUTRAL_BASE_ROF: 0.5,
+  BASE_LEVEL_VEHICLES: {
+    1: ['scout'],
+    2: ['scout', 'hauler', 'lightTank'],
+    3: ['basic', 'heavyTank'],
+    4: ['transport'],
+  },
   VEHICLE_TYPES: {
     scout:   { speed: 260, capacity: 120, energy: 0.015, hp: 60,  damage: 6,  rof: 1,   build: 1, cost: 800 },
     hauler:  { speed: 180, capacity: 400, energy: 0.03,  hp: 140, damage: 12, rof: 0.8, build: 3, cost: 1500 },
     basic:   { speed: 220, capacity: 200, energy: 0.02,  hp: 100, damage: 8,  rof: 1,   build: 2, cost: 1000 },
     lightTank: { speed: 200, capacity: 0,   energy: 0.04, hp: 180, damage: 20, rof: 1.2, build: 4, cost: 2000 },
     heavyTank: { speed: 150, capacity: 0,   energy: 0.06, hp: 300, damage: 35, rof: 0.8, build: 6, cost: 3500 },
+    transport: { speed: 150, capacity: 1000, energy: 0.05, hp: 200, damage: 0, rof: 0, build: 8, cost: 5000, harvestRate: 200, unloadTime: 0 },
   },
 };
 
@@ -88,6 +95,22 @@ function upgradeBase(playerId, baseId){
   b.level = lvl + 1;
   applyBaseStats(b);
   return true;
+}
+
+function spawnVehicle(playerId, baseId, vType){
+  const pl = players[playerId]; if (!pl) return { ok: false, msg: 'Player not found' };
+  const base = bases.find(b => b.id === baseId && b.owner === playerId); if (!base) return { ok: false, msg: 'Base not found' };
+  const lvl = base.level || 1;
+  const allowed = CFG.BASE_LEVEL_VEHICLES[lvl] || [];
+  if (!allowed.includes(vType)) return { ok: false, msg: 'Vehicle not available at this base level' };
+  const vt = CFG.VEHICLE_TYPES[vType];
+  if (!vt) return { ok: false, msg: 'Unknown vehicle type' };
+  if (pl.ore < vt.cost) return { ok: false, msg: 'Not enough ore to spawn vehicle' };
+  pl.ore -= vt.cost;
+  const readyAt = Date.now() + (vt.build || 0) * 1000;
+  if (!base.queue) base.queue = [];
+  base.queue.push({ vType, readyAt });
+  return { ok: true, msg: `Vehicle manufacturing (${vt.build || 0}s)` };
 }
 
 function seedResources(){
@@ -132,6 +155,7 @@ function snapshotState(){
       ENERGY_MAX: CFG.ENERGY_MAX,
       UNLOAD_TIME: CFG.UNLOAD_TIME,
       VEHICLE_TYPES: CFG.VEHICLE_TYPES,
+      BASE_LEVEL_VEHICLES: CFG.BASE_LEVEL_VEHICLES,
       BASE_ICON_SIZE,
       VEHICLE_ICON_SIZE,
       RESOURCE_ICON_SIZE,
@@ -217,17 +241,8 @@ wss.on('connection', (ws, req) => {
     const me = players[id]; if (!me) return;
 
     if (msg.type === 'spawnVehicle') {
-      const base = bases.find(b => b.id === msg.baseId && b.owner === id);
-      if (!base) return;
-      const vt = CFG.VEHICLE_TYPES[msg.vType] || CFG.VEHICLE_TYPES.basic;
-      if (me.ore >= vt.cost){
-        me.ore -= vt.cost;
-        const readyAt = Date.now() + (vt.build || 0) * 1000;
-        base.queue.push({ vType: msg.vType || 'basic', readyAt });
-        ws.send(JSON.stringify({ type: 'notice', ok: true, msg: `Vehicle manufacturing (${vt.build||0}s)` }));
-      } else {
-        ws.send(JSON.stringify({ type: 'notice', ok: false, msg: 'Not enough ore to spawn vehicle' }));
-      }
+      const res = spawnVehicle(id, msg.baseId, msg.vType || 'basic');
+      ws.send(JSON.stringify({ type: 'notice', ok: res.ok, msg: res.msg }));
     }
     else if (msg.type === 'moveVehicle') {
       const v = me.vehicles.find(v => v.id === msg.vehicleId);
@@ -286,6 +301,8 @@ function processManufacturing(now){
         hp: vt.hp,
         damage: vt.damage,
         rof: vt.rof,
+        harvestRate: vt.harvestRate,
+        unloadTime: vt.unloadTime,
         x: b.x + CFG.TILE_SIZE,
         y: b.y,
         tx: b.x + CFG.TILE_SIZE,
@@ -328,7 +345,6 @@ function resolveCaptures(){
 
 function gameLoop(){
   const dt = CFG.TICK_MS/1000;
-  const harvestStep = CFG.HARVEST_RATE * dt;
   const rechargeStep = CFG.ENERGY_RECHARGE * dt;
   const now = Date.now();
 
@@ -402,7 +418,7 @@ function gameLoop(){
           if (base && Math.hypot(v.x-base.x, v.y-base.y) < 30){
             if (v.state !== 'unloading'){
               v.state = 'unloading';
-              v.unloadTimer = CFG.UNLOAD_TIME;
+              v.unloadTimer = v.unloadTime ?? CFG.UNLOAD_TIME;
             } else {
               v.unloadTimer -= CFG.TICK_MS;
               if (v.unloadTimer <= 0){
@@ -416,6 +432,7 @@ function gameLoop(){
 
       // Harvest
       if (v.capacity > 0){
+        const harvestStep = (v.harvestRate || CFG.HARVEST_RATE) * dt;
         if (v.carrying >= v.capacity){
           if (v.state !== 'returning' && v.state !== 'unloading'){
             const b = nearestBase(pl, v.x, v.y);
@@ -521,4 +538,5 @@ module.exports = {
   handleDisconnect,
   upgradeBase,
   baseUpgradeCost,
+  spawnVehicle,
 };

--- a/tilearmy/test/spawn.test.js
+++ b/tilearmy/test/spawn.test.js
@@ -1,0 +1,54 @@
+process.env.NODE_ENV = 'test';
+const test = require('node:test');
+const assert = require('node:assert');
+const { CFG, players, bases, spawnVehicle, gameLoop } = require('../server');
+
+function resetState(){
+  bases.length = 0;
+  for (const k of Object.keys(players)) delete players[k];
+}
+
+test('base level restricts spawnable vehicles', () => {
+  resetState();
+  players.p1 = { bases: ['b1'], vehicles: [], ore: 1e6, lumber: 0, stone: 0, energy: CFG.ENERGY_MAX };
+  const base = { id: 'b1', x: 0, y: 0, owner: 'p1', level: 1, queue: [] };
+  bases.push(base);
+
+  assert.strictEqual(spawnVehicle('p1', 'b1', 'hauler').ok, false);
+  assert.strictEqual(spawnVehicle('p1', 'b1', 'scout').ok, true);
+
+  base.level = 2;
+  assert.strictEqual(spawnVehicle('p1', 'b1', 'hauler').ok, true);
+  assert.strictEqual(spawnVehicle('p1', 'b1', 'basic').ok, false);
+
+  base.level = 3;
+  assert.strictEqual(spawnVehicle('p1', 'b1', 'basic').ok, true);
+  assert.strictEqual(spawnVehicle('p1', 'b1', 'transport').ok, false);
+
+  base.level = 4;
+  assert.strictEqual(spawnVehicle('p1', 'b1', 'transport').ok, true);
+});
+
+test('transport unloads cargo instantly', () => {
+  resetState();
+  players.p1 = { bases: ['b1'], vehicles: [], ore: 0, lumber: 0, stone: 0, energy: CFG.ENERGY_MAX };
+  const base = { id: 'b1', x: 0, y: 0, owner: 'p1', hp: CFG.BASE_HP, damage: CFG.BASE_DAMAGE, rof: CFG.BASE_ROF, queue: [] };
+  bases.push(base);
+  const transport = {
+    id: 'v1', type: 'transport', speed: 0, capacity: 1000, energyCost: 0, hp: 100, damage: 0, rof: 0,
+    harvestRate: CFG.VEHICLE_TYPES.transport.harvestRate,
+    unloadTime: CFG.VEHICLE_TYPES.transport.unloadTime,
+    x: 0, y: 0, tx: 0, ty: 0,
+    carrying: 500, carryType: 'ore',
+    state: 'returning', targetRes: null, targetBase: 'b1', unloadTimer: 0,
+  };
+  players.p1.vehicles.push(transport);
+
+  gameLoop();
+  gameLoop();
+
+  assert.strictEqual(transport.carrying, 0);
+  assert.strictEqual(players.p1.ore, 500);
+  assert.strictEqual(transport.state, 'idle');
+});
+


### PR DESCRIPTION
## Summary
- Restrict vehicle spawning by base level with new mapping and transport unit at level 4
- Enforce spawn restrictions on the server and respect vehicle-specific unload and harvest rates
- Filter client spawn options by base level and document new transport vehicle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a03a4c045883278adc8f22dfdadd94