### PR TITLE
Optimize resource updates for large maps

### DIFF
--- a/tilearmy/public/client.js
+++ b/tilearmy/public/client.js
@@ -346,7 +346,16 @@
       updateCursorInfo();
       updateSpawnControls();
     } else if (msg.type === 'state') {
-      state = msg.state || state;
+      const s = msg.state || {};
+      if (s.players) state.players = s.players;
+      if (s.bases) state.bases = s.bases;
+      if (s.cfg) state.cfg = s.cfg;
+      if (s.resources) {
+        for (const res of s.resources) {
+          const idx = state.resources.findIndex(r => r.id === res.id);
+          if (idx >= 0) state.resources[idx] = res; else state.resources.push(res);
+        }
+      }
       const p = state.players[myId] || {};
       const cur = (p.bases || []).join(',') + '|' +
         (p.vehicles || []).map(v=>v.id+v.state+Math.floor(v.carrying||0)).join(',') + '|' +

--- a/tilearmy/test/resources.test.js
+++ b/tilearmy/test/resources.test.js
@@ -1,0 +1,25 @@
+process.env.NODE_ENV = 'test';
+const test = require('node:test');
+const assert = require('node:assert');
+const { resources, snapshotState } = require('../server');
+
+test('snapshotState only includes changed resources when not full', () => {
+  resources.length = 0;
+  resources.push({ id: 'r1', type: 'ore', x: 0, y: 0, amount: 100, changed: false });
+  resources.push({ id: 'r2', type: 'lumber', x: 10, y: 10, amount: 200, changed: false });
+
+  let snap = snapshotState(false);
+  assert.strictEqual(snap.resources.length, 0);
+
+  resources[0].amount = 90;
+  resources[0].changed = true;
+
+  snap = snapshotState(false);
+  assert.strictEqual(snap.resources.length, 1);
+  assert.strictEqual(snap.resources[0].id, 'r1');
+
+  // simulate send clearing the changed flag
+  snap.resources.forEach(r => { r.changed = false; });
+  snap = snapshotState(false);
+  assert.strictEqual(snap.resources.length, 0);
+});


### PR DESCRIPTION
## Summary
- Reduce network load by only broadcasting changed resources to clients
- Update client to merge incremental resource updates
- Cover resource update logic with tests

## Testing
- `npm test --prefix tilearmy`


------
https://chatgpt.com/codex/tasks/task_e_68a1863d90c48327b73739db8dae2b62