### PR TITLE
refactor: unify entity storage

### DIFF
--- a/tilearmy/test/combat.test.js
+++ b/tilearmy/test/combat.test.js
@@ -1,11 +1,12 @@
 process.env.NODE_ENV = 'test';
 const test = require('node:test');
 const assert = require('node:assert');
-const { CFG, players, bases, resources, processManufacturing, resolveCaptures } = require('../server');
+const { CFG, players, entities, getEntitiesByType, processManufacturing, resolveCaptures } = require('../server');
+const bases = () => getEntitiesByType('base');
+const resources = () => getEntitiesByType('resource');
 
 function resetState(){
-  bases.length = 0;
-  resources.length = 0;
+  entities.length = 0;
   for (const k of Object.keys(players)) delete players[k];
 }
 
@@ -13,8 +14,8 @@ test('base captured after HP reaches zero', () => {
   resetState();
   players.attacker = { bases: ['h0'], vehicles: [] };
   players.defender = { bases: ['b1'], vehicles: [] };
-  const base = { id: 'b1', x: 0, y: 0, owner: 'defender', hp: 0, damage: CFG.NEUTRAL_BASE_DAMAGE, rof: CFG.NEUTRAL_BASE_ROF, queue: [], lastAttacker: 'attacker' };
-  bases.push(base);
+  const base = { id: 'b1', type: 'base', x: 0, y: 0, owner: 'defender', hp: 0, damage: CFG.NEUTRAL_BASE_DAMAGE, rof: CFG.NEUTRAL_BASE_ROF, queue: [], lastAttacker: 'attacker' };
+  entities.push(base);
 
   resolveCaptures();
 
@@ -29,8 +30,8 @@ test('manufacturing queue spawns vehicle when ready', () => {
   resetState();
   players.p1 = { bases: ['b1'], vehicles: [] };
   const now = Date.now();
-  const base = { id: 'b1', x: 0, y: 0, owner: 'p1', hp: CFG.BASE_HP, damage: CFG.BASE_DAMAGE, rof: CFG.BASE_ROF, queue: [{ vType: 'basic', readyAt: now - 1000 }] };
-  bases.push(base);
+  const base = { id: 'b1', type: 'base', x: 0, y: 0, owner: 'p1', hp: CFG.BASE_HP, damage: CFG.BASE_DAMAGE, rof: CFG.BASE_ROF, queue: [{ vType: 'basic', readyAt: now - 1000 }] };
+  entities.push(base);
 
   processManufacturing(now);
 

--- a/tilearmy/test/reconnect.test.js
+++ b/tilearmy/test/reconnect.test.js
@@ -2,11 +2,12 @@ process.env.NODE_ENV = 'test';
 process.env.OFFLINE_TIMEOUT_MS = 100;
 const test = require('node:test');
 const assert = require('node:assert');
-const { CFG, players, bases, resources, connections, handleDisconnect, gameLoop } = require('../server');
+const { CFG, players, entities, getEntitiesByType, connections, handleDisconnect, gameLoop } = require('../server');
+const bases = () => getEntitiesByType('base');
+const resources = () => getEntitiesByType('resource');
 
 function resetState(){
-  bases.length = 0;
-  resources.length = 0;
+  entities.length = 0;
   for (const k of Object.keys(players)) delete players[k];
   for (const k of Object.keys(connections)) delete connections[k];
 }
@@ -14,8 +15,8 @@ function resetState(){
 test('vehicles persist after reconnect', () => {
   resetState();
   players.p1 = { bases: ['b1'], vehicles: [], ore: 0, lumber: 0, stone: 0, energy: CFG.ENERGY_MAX, disconnectedAt: Date.now() - CFG.OFFLINE_TIMEOUT - 10, offline: false };
-  const base = { id: 'b1', x: 0, y: 0, owner: 'p1', hp: CFG.BASE_HP, damage: CFG.BASE_DAMAGE, rof: CFG.BASE_ROF, queue: [] };
-  bases.push(base);
+  const base = { id: 'b1', type: 'base', x: 0, y: 0, owner: 'p1', hp: CFG.BASE_HP, damage: CFG.BASE_DAMAGE, rof: CFG.BASE_ROF, queue: [] };
+  entities.push(base);
   const vehicle = {
     id: 'v1', type: 'basic', speed: 1000, capacity: 100, energyCost: 0, hp: 100, damage: 0, rof: 0,
     x: 100, y: 0, tx: 100, ty: 0,

--- a/tilearmy/test/spawn.test.js
+++ b/tilearmy/test/spawn.test.js
@@ -1,18 +1,19 @@
 process.env.NODE_ENV = 'test';
 const test = require('node:test');
 const assert = require('node:assert');
-const { CFG, players, bases, spawnVehicle, gameLoop } = require('../server');
+const { CFG, players, entities, getEntitiesByType, spawnVehicle, gameLoop } = require('../server');
+const bases = () => getEntitiesByType('base');
 
 function resetState(){
-  bases.length = 0;
+  entities.length = 0;
   for (const k of Object.keys(players)) delete players[k];
 }
 
 test('base level restricts spawnable vehicles', () => {
   resetState();
   players.p1 = { bases: ['b1'], vehicles: [], ore: 1e6, lumber: 0, stone: 0, energy: CFG.ENERGY_MAX };
-  const base = { id: 'b1', x: 0, y: 0, owner: 'p1', level: 1, queue: [] };
-  bases.push(base);
+  const base = { id: 'b1', type: 'base', x: 0, y: 0, owner: 'p1', level: 1, queue: [] };
+  entities.push(base);
 
   assert.strictEqual(spawnVehicle('p1', 'b1', 'hauler').ok, false);
   assert.strictEqual(spawnVehicle('p1', 'b1', 'scout').ok, true);
@@ -34,8 +35,8 @@ test('base level restricts spawnable vehicles', () => {
 test('transport unloads cargo instantly', () => {
   resetState();
   players.p1 = { bases: ['b1'], vehicles: [], ore: 0, lumber: 0, stone: 0, energy: CFG.ENERGY_MAX };
-  const base = { id: 'b1', x: 0, y: 0, owner: 'p1', hp: CFG.BASE_HP, damage: CFG.BASE_DAMAGE, rof: CFG.BASE_ROF, queue: [] };
-  bases.push(base);
+  const base = { id: 'b1', type: 'base', x: 0, y: 0, owner: 'p1', hp: CFG.BASE_HP, damage: CFG.BASE_DAMAGE, rof: CFG.BASE_ROF, queue: [] };
+  entities.push(base);
   const transport = {
     id: 'v1', type: 'transport', speed: 0, capacity: 1000, energyCost: 0, hp: 100, damage: 0, rof: 0,
     harvestRate: CFG.VEHICLE_TYPES.transport.harvestRate,

--- a/tilearmy/test/unload.test.js
+++ b/tilearmy/test/unload.test.js
@@ -1,19 +1,20 @@
 process.env.NODE_ENV = 'test';
 const test = require('node:test');
 const assert = require('node:assert');
-const { CFG, players, bases, resources, gameLoop } = require('../server');
+const { CFG, players, entities, getEntitiesByType, gameLoop } = require('../server');
+const bases = () => getEntitiesByType('base');
+const resources = () => getEntitiesByType('resource');
 
 function resetState(){
-  bases.length = 0;
-  resources.length = 0;
+  entities.length = 0;
   for (const k of Object.keys(players)) delete players[k];
 }
 
 test('vehicle unloads cargo after delay', () => {
   resetState();
   players.p1 = { bases: ['b1'], vehicles: [], ore: 0, lumber: 0, stone: 0, energy: CFG.ENERGY_MAX };
-  const base = { id: 'b1', x: 0, y: 0, owner: 'p1', hp: CFG.BASE_HP, damage: CFG.BASE_DAMAGE, rof: CFG.BASE_ROF, queue: [] };
-  bases.push(base);
+  const base = { id: 'b1', type: 'base', x: 0, y: 0, owner: 'p1', hp: CFG.BASE_HP, damage: CFG.BASE_DAMAGE, rof: CFG.BASE_ROF, queue: [] };
+  entities.push(base);
   const vehicle = {
     id: 'v1', type: 'basic', speed: 0, capacity: 100, energyCost: 0, hp: 100, damage: 0, rof: 0,
     x: 0, y: 0, tx: 0, ty: 0,

--- a/tilearmy/test/upgrade.test.js
+++ b/tilearmy/test/upgrade.test.js
@@ -1,18 +1,19 @@
 process.env.NODE_ENV = 'test';
 const test = require('node:test');
 const assert = require('node:assert');
-const { CFG, players, bases, upgradeBase, baseUpgradeCost } = require('../server');
+const { CFG, players, entities, getEntitiesByType, upgradeBase, baseUpgradeCost } = require('../server');
+const bases = () => getEntitiesByType('base');
 
 function resetState(){
-  bases.length = 0;
+  entities.length = 0;
   for (const k of Object.keys(players)) delete players[k];
 }
 
 test('upgrading a base consumes resources and boosts stats', () => {
   resetState();
   players.p1 = { bases: ['b1'], vehicles: [], lumber: 500, stone: 500 };
-  const base = { id: 'b1', x: 0, y: 0, owner: 'p1', level: 1, queue: [] };
-  bases.push(base);
+  const base = { id: 'b1', type: 'base', x: 0, y: 0, owner: 'p1', level: 1, queue: [] };
+  entities.push(base);
   // base stats before upgrade
   base.hp = CFG.BASE_HP;
   base.damage = CFG.BASE_DAMAGE;


### PR DESCRIPTION
## Summary
- consolidate bases and resources into a unified entity list with lookup helpers
- adapt game logic to work through entity accessors
- update tests to exercise the new entity store

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1bdba92508327b318a0fdadebef42