### PR TITLE
Send incremental map updates

### DIFF
--- a/tilearmy/bot.py
+++ b/tilearmy/bot.py
@@ -59,6 +59,11 @@ async def bot_player(
                     if me:
                         for k in resources:
                             resources[k] = me.get(k, resources[k])
+                elif data.get("type") == "update":
+                    for ent in data.get("entities", []):
+                        if ent.get("kind") == "player" and ent.get("id") == name:
+                            for k in resources:
+                                resources[k] = ent.get(k, resources[k])
                 if verbose:
                     print(f"[{name}] <- {data}")
 

--- a/tilearmy/test/state_update.test.js
+++ b/tilearmy/test/state_update.test.js
@@ -3,7 +3,7 @@ const test = require('node:test');
 const assert = require('node:assert');
 const WebSocket = require('ws');
 
-test('state updates are throttled and only sent on change', () => {
+test('state updates are throttled and only send changed entities', () => {
   const realNow = Date.now;
   let now = 0;
   Date.now = () => now;
@@ -19,7 +19,7 @@ test('state updates are throttled and only sent on change', () => {
   wss.clients.clear();
 
   const messages = [];
-  const fake = { readyState: WebSocket.OPEN, send: m => messages.push(m) };
+  const fake = { readyState: WebSocket.OPEN, send: m => messages.push(JSON.parse(m)) };
   wss.clients.add(fake);
 
   try {
@@ -33,6 +33,11 @@ test('state updates are throttled and only sent on change', () => {
     now = 1100;
     gameLoop();
     assert.strictEqual(messages.length, 1);
+    assert.strictEqual(messages[0].type, 'update');
+    assert.ok(Array.isArray(messages[0].entities));
+    const pMsg = messages[0].entities.find(e => e.kind === 'player' && e.id === 'p1');
+    assert.ok(pMsg);
+    assert.strictEqual(messages[0].cfg, undefined);
 
     // State changes again but within a second -> still only one broadcast
     now = 1500;


### PR DESCRIPTION
## Summary
- Broadcast only changed game entities each tick instead of full map
- Send initial configuration only when a client connects and update client and bot to handle incremental updates
- Expand tests to verify throttled incremental updates

## Testing
- `npm test`
- `PYTHONPATH=. pytest tilearmy/test_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2c29d6cc88327a31dda2cd888b588