### PR TITLE
Document server and client game loops

### DIFF
--- a/tilearmy/client_game_loop.txt
+++ b/tilearmy/client_game_loop.txt
@@ -1,0 +1,12 @@
+The TileArmy client renders and predicts game state inside a draw loop driven by requestAnimationFrame.
+
+1. If the browser tab is hidden, reset timing and schedule the next frame without rendering.
+2. Compute the elapsed time and enforce a 30 FPS cap to limit CPU usage.
+3. Clear the canvas and update the camera, either following the selected unit or reacting to keyboard input with friction.
+4. Extrapolate vehicle movement and cargo loading from queued server updates, then smooth positions to avoid jitter.
+5. Run lightweight combat logic to spawn bullet visuals and advance existing projectiles.
+6. Draw the scene in layers: background, grid, resources, bases, vehicles, bullets.
+7. Refresh cursor and UI information.
+8. Request the next animation frame to continue the loop.
+
+This loop keeps the client's display responsive while staying in sync with server state.

--- a/tilearmy/game_loop.txt
+++ b/tilearmy/game_loop.txt
@@ -1,0 +1,20 @@
+The TileArmy server advances the game state in a loop that runs every tick (CFG.TICK_MS = 50ms).
+
+1. Compute the duration of the tick in seconds and the amount of energy that players regenerate.
+2. Process any vehicle manufacturing queues for bases.
+3. Determine which resource nodes are currently targeted so multiple vehicles do not claim the same resource.
+4. For each player:
+   - Mark the player offline if they have been disconnected for too long.
+   - For each vehicle:
+     * If the player is offline, recall the vehicle to the nearest base.
+     * If online and the vehicle has capacity, automatically select a nearby unclaimed resource to harvest.
+     * Move the vehicle toward its target and deduct energy based on movement.
+     * When arriving at a base, unload collected resources after a delay.
+     * Harvest from a target resource while within range, filling the vehicle and depleting the node. Full or empty nodes send the vehicle back to base.
+     * Apply damage to enemy bases that are within attack range.
+   - Remove any vehicles that were destroyed and update the player's energy by subtracting spent energy and adding regeneration.
+5. For each base, damage nearby enemy vehicles based on the base's attack stats and remove any vehicles destroyed by this attack.
+6. Resolve base captures by determining ownership based on nearby units.
+7. Create a snapshot of the current state and, at most once per second, broadcast only the entities that have changed since the last snapshot to all connected clients.
+
+This loop keeps the real-time game world progressing and synchronizes updates with connected players.


### PR DESCRIPTION
## Summary
- add a dedicated `game_loop.txt` describing how the server's tick-driven loop manages resources, units, bases, and broadcasting
- add `client_game_loop.txt` documenting how the browser render loop updates camera, predicts movement, draws layers, and schedules frames

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3cb39e03483279da195687478dfbf