### PR TITLE
Add ingestion service and retention API

### DIFF
--- a/homecam/README.md
+++ b/homecam/README.md
@@ -22,6 +22,13 @@ uvicorn homecam.backend.main:app --reload
 
 The API will be available at http://localhost:8000.
 
+To run on a different port, provide the `--port` option. For example, to listen on port
+`9000`:
+
+```bash
+uvicorn homecam.backend.main:app --reload --port 9000
+```
+
 ## Example usage
 ### Add a camera
 ```bash

--- a/homecam/README.md
+++ b/homecam/README.md
@@ -40,10 +40,10 @@ curl -X POST http://localhost:8000/cameras \
         "id": "front",
         "name": "Front Door",
         "rtsp_url": "rtsp://example/stream",
-        "storage_path": "./recordings/front",
         "retention_days": 7
       }'
 ```
+The `storage_path` field is optional. If omitted, recordings default to `./recordings/<id>`.
 
 ### List cameras
 ```bash
@@ -66,6 +66,14 @@ Use a player such as [hls.js](https://github.com/video-dev/hls.js/) in the front
 The playlist files are created immediately, but it may take a few seconds after adding a
 camera for `ffmpeg` to begin writing segments. If the playlist contains only `#EXTM3U`,
 wait briefly and try again to allow the stream to start.
+
+## Frontend
+
+A minimal frontend is served by the FastAPI app:
+
+- `http://localhost:8000/` shows a grid of low-bandwidth streams for all cameras.
+- `http://localhost:8000/manage` provides a form to add or edit cameras. Leave the
+  storage path blank to use the default directory under `./recordings`.
 
 ## Manual testing
 1. **Verify recording** – After adding a camera, check that the configured `storage_path` contains timestamped `.mp4` files created by `ffmpeg`.

--- a/homecam/README.md
+++ b/homecam/README.md
@@ -61,6 +61,10 @@ After adding a camera, low- and high-quality HLS playlists are available:
 
 Use a player such as [hls.js](https://github.com/video-dev/hls.js/) in the frontend to view these streams.
 
+The playlist files are created immediately, but it may take a few seconds after adding a
+camera for `ffmpeg` to begin writing segments. If the playlist contains only `#EXTM3U`,
+wait briefly and try again to allow the stream to start.
+
 ## Manual testing
 1. **Verify recording** – After adding a camera, check that the configured `storage_path` contains timestamped `.mp4` files created by `ffmpeg`.
 2. **Verify live streams** – Fetch the HLS playlist for a camera:

--- a/homecam/README.md
+++ b/homecam/README.md
@@ -21,6 +21,8 @@ uvicorn homecam.backend.main:app --reload
 ```
 
 The API will be available at http://localhost:8000.
+Existing camera configurations in `camera_config.json` are automatically
+resumed and begin recording when the server starts.
 
 To run on a different port, provide the `--port` option. For example, to listen on port
 `9000`:

--- a/homecam/README.md
+++ b/homecam/README.md
@@ -53,9 +53,21 @@ curl http://localhost:8000/cameras
 curl -X DELETE http://localhost:8000/cameras/front
 ```
 
+### Live streams
+After adding a camera, low- and high-quality HLS playlists are available:
+
+- `http://localhost:8000/streams/<camera_id>/low/index.m3u8`
+- `http://localhost:8000/streams/<camera_id>/high/index.m3u8`
+
+Use a player such as [hls.js](https://github.com/video-dev/hls.js/) in the frontend to view these streams.
+
 ## Manual testing
 1. **Verify recording** – After adding a camera, check that the configured `storage_path` contains timestamped `.mp4` files created by `ffmpeg`.
-2. **Verify retention** – Run the cleanup utility to remove recordings older than the retention period:
+2. **Verify live streams** – Fetch the HLS playlist for a camera:
+   ```bash
+   curl http://localhost:8000/streams/front/low/index.m3u8
+   ```
+3. **Verify retention** – Run the cleanup utility to remove recordings older than the retention period:
    ```bash
    python - <<'PY'
 from pathlib import Path
@@ -63,7 +75,7 @@ from homecam.backend.retention import cleanup_old_recordings
 cleanup_old_recordings(Path('./recordings/front'), retention_days=7)
 PY
    ```
-3. **Run unit tests** – Execute the pytest suite:
+4. **Run unit tests** – Execute the pytest suite:
    ```bash
    python -m pytest -q
    ```

--- a/homecam/README.md
+++ b/homecam/README.md
@@ -1,0 +1,64 @@
+# HomeCam
+
+HomeCam is a lightweight home camera surveillance backend implemented with FastAPI and `ffmpeg`. It records RTSP camera streams, keeps per-camera retention policies, and exposes a simple API for configuration.
+
+## Requirements
+- Python 3.11+
+- `ffmpeg` available on the system `PATH`
+
+## Installation
+Install the Python dependencies:
+
+```bash
+pip install fastapi pydantic uvicorn websockets
+```
+
+## Running the API server
+Start the FastAPI application with `uvicorn`:
+
+```bash
+uvicorn homecam.backend.main:app --reload
+```
+
+The API will be available at http://localhost:8000.
+
+## Example usage
+### Add a camera
+```bash
+curl -X POST http://localhost:8000/cameras \
+  -H "Content-Type: application/json" \
+  -d '{
+        "id": "front",
+        "name": "Front Door",
+        "rtsp_url": "rtsp://example/stream",
+        "storage_path": "./recordings/front",
+        "retention_days": 7
+      }'
+```
+
+### List cameras
+```bash
+curl http://localhost:8000/cameras
+```
+
+### Remove a camera
+```bash
+curl -X DELETE http://localhost:8000/cameras/front
+```
+
+## Manual testing
+1. **Verify recording** – After adding a camera, check that the configured `storage_path` contains timestamped `.mp4` files created by `ffmpeg`.
+2. **Verify retention** – Run the cleanup utility to remove recordings older than the retention period:
+   ```bash
+   python - <<'PY'
+from pathlib import Path
+from homecam.backend.retention import cleanup_old_recordings
+cleanup_old_recordings(Path('./recordings/front'), retention_days=7)
+PY
+   ```
+3. **Run unit tests** – Execute the pytest suite:
+   ```bash
+   python -m pytest -q
+   ```
+
+These steps ensure that the API endpoints work, recordings are written, and old footage is pruned according to your retention policy.

--- a/homecam/ROADMAP.txt
+++ b/homecam/ROADMAP.txt
@@ -24,10 +24,11 @@ Phases
    - Implement cleanup job that removes files older than configured retention period.
    - Allow global default settings overridden per camera.
 
-4. **Live View** *(implemented)*
+4. **Live View** *(in progress)*
    - Backend generates low-bandwidth preview streams (e.g., using HLS with reduced resolution/bitrate).
    - Use the per-camera `ffmpeg` process to also produce a high-resolution stream while recording, mapping outputs for low and high quality feeds.
    - Frontend dashboard displays cameras in a grid with these preview streams.
+   - Camera management page allows adding and editing cameras with an optional storage path override.
    - Enable user to select a camera for high‑resolution stream (full HLS/WebRTC feed).
 
 5. **Recorded Video Playback**
@@ -52,6 +53,6 @@ Milestones
 ---------
 - M1: Basic RTSP ingestion and file storage. (implemented)
 - M2: Configurable retention and management API. (implemented)
-- M3: Live low-bandwidth grid view & high-res view. (implemented)
+- M3: Live low-bandwidth grid view & high-res view. (in progress)
 - M4: Recorded playback UI.
 - M5: Motion detection prototype.

--- a/homecam/ROADMAP.txt
+++ b/homecam/ROADMAP.txt
@@ -24,7 +24,7 @@ Phases
    - Implement cleanup job that removes files older than configured retention period.
    - Allow global default settings overridden per camera.
 
-4. **Live View**
+4. **Live View** *(implemented)*
    - Backend generates low-bandwidth preview streams (e.g., using HLS with reduced resolution/bitrate).
    - Use the per-camera `ffmpeg` process to also produce a high-resolution stream while recording, mapping outputs for low and high quality feeds.
    - Frontend dashboard displays cameras in a grid with these preview streams.
@@ -52,6 +52,6 @@ Milestones
 ---------
 - M1: Basic RTSP ingestion and file storage. (implemented)
 - M2: Configurable retention and management API. (implemented)
-- M3: Live low-bandwidth grid view & high-res view.
+- M3: Live low-bandwidth grid view & high-res view. (implemented)
 - M4: Recorded playback UI.
 - M5: Motion detection prototype.

--- a/homecam/ROADMAP.txt
+++ b/homecam/ROADMAP.txt
@@ -1,0 +1,57 @@
+Home Camera Surveillance System Roadmap
+======================================
+
+Overview
+--------
+This document outlines the steps to develop a home camera surveillance system with a JavaScript/Python backend and web-based frontend. The system will support adding RTSP streams, configurable video storage, retention policies, live viewing, recorded playback, and future motion detection.
+
+Phases
+------
+
+1. **Project Setup**
+   - Initialize repository structure for backend (Python services + Node.js REST API) and frontend.
+   - Choose frontend technology. Beyond React, lightweight alternatives include Preact, Svelte, or vanilla JS libraries like HTMX, which have fewer dependencies.
+   - Define configuration files for storing system settings (YAML/JSON).
+
+2. **RTSP Stream Management**
+   - Implement API endpoints to register, update, and remove camera streams. Each camera includes RTSP URL, name, and storage settings.
+   - Create Python service using `ffmpeg`/`gstreamer` to ingest RTSP streams and write video segments.
+   - Employ a single `ffmpeg` process per camera with filter graphs to simultaneously record to disk and generate multiple outputs.
+   - Support per-camera configuration for output directory and retention duration.
+
+3. **Video Storage & Retention**
+   - Standardize directory structure: `/storage/<camera_id>/<date>/<time>.mp4`.
+   - Implement cleanup job that removes files older than configured retention period.
+   - Allow global default settings overridden per camera.
+
+4. **Live View**
+   - Backend generates low-bandwidth preview streams (e.g., using HLS with reduced resolution/bitrate).
+   - Use the per-camera `ffmpeg` process to also produce a high-resolution stream while recording, mapping outputs for low and high quality feeds.
+   - Frontend dashboard displays cameras in a grid with these preview streams.
+   - Enable user to select a camera for high‑resolution stream (full HLS/WebRTC feed).
+
+5. **Recorded Video Playback**
+   - API to list recordings by camera and date/time.
+   - Frontend browser to navigate by camera -> date -> time and play selected recording.
+
+6. **Authentication & Permissions**
+   - Integrate user management and auth (JWT or session-based).
+   - Restrict camera viewing and configuration to authorized users.
+
+7. **Future: Motion Detection**
+   - Add Python service using OpenCV or similar to analyze video frames for motion.
+   - Trigger events/logging and mark recordings with motion timestamps.
+   - Optional notifications via webhooks or mobile push.
+
+8. **Deployment & Configuration**
+   - Containerize services with Docker.
+   - Provide configuration for storage paths, retention, and camera definitions via environment variables or config files.
+   - Document setup and provide scripts for installing dependencies and starting services.
+
+Milestones
+---------
+- M1: Basic RTSP ingestion and file storage. (implemented)
+- M2: Configurable retention and management API. (implemented)
+- M3: Live low-bandwidth grid view & high-res view.
+- M4: Recorded playback UI.
+- M5: Motion detection prototype.

--- a/homecam/__init__.py
+++ b/homecam/__init__.py
@@ -1,0 +1,1 @@
+"""Home camera surveillance system package."""

--- a/homecam/backend/__init__.py
+++ b/homecam/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend services for the home camera surveillance system."""

--- a/homecam/backend/camera_manager.py
+++ b/homecam/backend/camera_manager.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict
+
+from .recorder import Recorder
+
+
+@dataclass
+class CameraConfig:
+    """Configuration for a single camera."""
+
+    id: str
+    name: str
+    rtsp_url: str
+    storage_path: Path
+    retention_days: int
+
+
+class CameraManager:
+    """Manage camera configurations and recording processes."""
+
+    def __init__(self, config_file: Path):
+        self.config_file = config_file
+        self.cameras: Dict[str, CameraConfig] = {}
+        self.recorders: Dict[str, Recorder] = {}
+        if self.config_file.exists():
+            self._load()
+
+    # ------------------------------------------------------------------
+    # Configuration persistence
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        data = json.loads(self.config_file.read_text())
+        for cid, cfg in data.items():
+            self.cameras[cid] = CameraConfig(
+                id=cid,
+                name=cfg["name"],
+                rtsp_url=cfg["rtsp_url"],
+                storage_path=Path(cfg["storage_path"]),
+                retention_days=cfg["retention_days"],
+            )
+
+    def _save(self) -> None:
+        data = {
+            cid: {
+                "name": c.name,
+                "rtsp_url": c.rtsp_url,
+                "storage_path": str(c.storage_path),
+                "retention_days": c.retention_days,
+            }
+            for cid, c in self.cameras.items()
+        }
+        self.config_file.write_text(json.dumps(data, indent=2))
+
+    # ------------------------------------------------------------------
+    # Camera management
+    # ------------------------------------------------------------------
+    def add_camera(self, camera: CameraConfig) -> None:
+        """Register a camera and start recording."""
+        self.cameras[camera.id] = camera
+        self._save()
+        recorder = Recorder(camera)
+        recorder.start()
+        self.recorders[camera.id] = recorder
+
+    def remove_camera(self, camera_id: str) -> None:
+        """Stop recording and remove camera from registry."""
+        recorder = self.recorders.pop(camera_id, None)
+        if recorder:
+            recorder.stop()
+        self.cameras.pop(camera_id, None)
+        self._save()
+
+    def list_cameras(self) -> Dict[str, CameraConfig]:
+        """Return a mapping of camera IDs to configs."""
+        return self.cameras

--- a/homecam/backend/camera_manager.py
+++ b/homecam/backend/camera_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict
+from typing import Any, Dict
 
 from .recorder import Recorder
 
@@ -17,6 +17,20 @@ class CameraConfig:
     rtsp_url: str
     storage_path: Path
     retention_days: int
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize config including stream URLs."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "rtsp_url": self.rtsp_url,
+            "storage_path": str(self.storage_path),
+            "retention_days": self.retention_days,
+            "stream_urls": {
+                "low": f"/streams/{self.id}/low/index.m3u8",
+                "high": f"/streams/{self.id}/high/index.m3u8",
+            },
+        }
 
 
 class CameraManager:

--- a/homecam/backend/camera_manager.py
+++ b/homecam/backend/camera_manager.py
@@ -42,6 +42,10 @@ class CameraManager:
         self.recorders: Dict[str, Recorder] = {}
         if self.config_file.exists():
             self._load()
+            for cam in self.cameras.values():
+                rec = Recorder(cam)
+                rec.start()
+                self.recorders[cam.id] = rec
 
     # ------------------------------------------------------------------
     # Configuration persistence

--- a/homecam/backend/main.py
+++ b/homecam/backend/main.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from .camera_manager import CameraConfig, CameraManager
+
+app = FastAPI(title="HomeCam API")
+manager = CameraManager(Path("camera_config.json"))
+
+
+class CameraIn(BaseModel):
+    id: str
+    name: str
+    rtsp_url: str
+    storage_path: str
+    retention_days: int
+
+
+@app.post("/cameras")
+def add_camera(camera: CameraIn) -> dict[str, str]:
+    config = CameraConfig(
+        id=camera.id,
+        name=camera.name,
+        rtsp_url=camera.rtsp_url,
+        storage_path=Path(camera.storage_path),
+        retention_days=camera.retention_days,
+    )
+    manager.add_camera(config)
+    return {"status": "added"}
+
+
+@app.get("/cameras")
+def list_cameras() -> dict[str, CameraConfig]:
+    return manager.list_cameras()
+
+
+@app.delete("/cameras/{camera_id}")
+def delete_camera(camera_id: str) -> dict[str, str]:
+    if camera_id not in manager.cameras:
+        raise HTTPException(status_code=404, detail="Camera not found")
+    manager.remove_camera(camera_id)
+    return {"status": "removed"}

--- a/homecam/backend/main.py
+++ b/homecam/backend/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
@@ -7,6 +8,17 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
 from .camera_manager import CameraConfig, CameraManager
+from .recorder import Recorder
+
+if os.environ.get("HOMECAM_TESTING"):
+    def _noop(self):
+        return None
+    Recorder.start = _noop  # type: ignore
+
+DEFAULT_STORAGE = Path("recordings")
+DEFAULT_STORAGE.mkdir(exist_ok=True)
+
+FRONTEND_DIR = Path(__file__).resolve().parent.parent / "frontend"
 
 app = FastAPI(title="HomeCam API")
 manager = CameraManager(Path("camera_config.json"))
@@ -16,17 +28,18 @@ class CameraIn(BaseModel):
     id: str
     name: str
     rtsp_url: str
-    storage_path: str
+    storage_path: str | None = None
     retention_days: int
 
 
 @app.post("/cameras")
 def add_camera(camera: CameraIn) -> dict[str, str]:
+    storage = Path(camera.storage_path) if camera.storage_path else DEFAULT_STORAGE / camera.id
     config = CameraConfig(
         id=camera.id,
         name=camera.name,
         rtsp_url=camera.rtsp_url,
-        storage_path=Path(camera.storage_path),
+        storage_path=storage,
         retention_days=camera.retention_days,
     )
     manager.add_camera(config)
@@ -44,6 +57,21 @@ def delete_camera(camera_id: str) -> dict[str, str]:
         raise HTTPException(status_code=404, detail="Camera not found")
     manager.remove_camera(camera_id)
     return {"status": "removed"}
+
+
+@app.get("/defaults")
+def defaults() -> dict[str, str]:
+    return {"storage_path": str(DEFAULT_STORAGE)}
+
+
+@app.get("/")
+def index() -> FileResponse:
+    return FileResponse(FRONTEND_DIR / "index.html")
+
+
+@app.get("/manage")
+def manage_page() -> FileResponse:
+    return FileResponse(FRONTEND_DIR / "manage.html")
 
 
 @app.get("/streams/{camera_id}/{quality}/{filename:path}")

--- a/homecam/backend/recorder.py
+++ b/homecam/backend/recorder.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import subprocess
 from datetime import datetime
 from pathlib import Path
+from typing import List
 
 
 class Recorder:
@@ -12,19 +13,65 @@ class Recorder:
         self.camera = camera
         self.process: subprocess.Popen | None = None
 
-    def start(self) -> None:
-        output_dir = Path(self.camera.storage_path)
-        output_dir.mkdir(parents=True, exist_ok=True)
-        filename = datetime.utcnow().strftime("%Y%m%d_%H%M%S.mp4")
-        cmd = [
+    def _build_ffmpeg_cmd(
+        self, record_path: Path, low_playlist: Path, high_playlist: Path
+    ) -> List[str]:
+        """Build ffmpeg command for recording and HLS streaming."""
+
+        return [
             "ffmpeg",
             "-y",
             "-i",
             self.camera.rtsp_url,
+            # Full-quality recording
+            "-map",
+            "0",
             "-c",
             "copy",
-            str(output_dir / filename),
+            str(record_path),
+            # Low-bandwidth stream
+            "-map",
+            "0",
+            "-vf",
+            "scale=640:-2",
+            "-c:v",
+            "libx264",
+            "-b:v",
+            "500k",
+            "-f",
+            "hls",
+            "-hls_time",
+            "2",
+            "-hls_list_size",
+            "3",
+            str(low_playlist),
+            # High-resolution stream
+            "-map",
+            "0",
+            "-c:v",
+            "libx264",
+            "-b:v",
+            "3000k",
+            "-f",
+            "hls",
+            "-hls_time",
+            "2",
+            "-hls_list_size",
+            "3",
+            str(high_playlist),
         ]
+
+    def start(self) -> None:
+        record_dir = Path(self.camera.storage_path)
+        low_dir = record_dir / "streams" / "low"
+        high_dir = record_dir / "streams" / "high"
+        for d in (record_dir, low_dir, high_dir):
+            d.mkdir(parents=True, exist_ok=True)
+        filename = datetime.utcnow().strftime("%Y%m%d_%H%M%S.mp4")
+        record_path = record_dir / filename
+        cmd = self._build_ffmpeg_cmd(
+            record_path, low_dir / "index.m3u8", high_dir / "index.m3u8"
+        )
         self.process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     def stop(self) -> None:

--- a/homecam/backend/recorder.py
+++ b/homecam/backend/recorder.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+
+class Recorder:
+    """Spawn an ffmpeg process to record a camera stream."""
+
+    def __init__(self, camera: "CameraConfig"):
+        self.camera = camera
+        self.process: subprocess.Popen | None = None
+
+    def start(self) -> None:
+        output_dir = Path(self.camera.storage_path)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        filename = datetime.utcnow().strftime("%Y%m%d_%H%M%S.mp4")
+        cmd = [
+            "ffmpeg",
+            "-y",
+            "-i",
+            self.camera.rtsp_url,
+            "-c",
+            "copy",
+            str(output_dir / filename),
+        ]
+        self.process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    def stop(self) -> None:
+        if self.process and self.process.poll() is None:
+            self.process.terminate()
+            self.process.wait()
+        self.process = None

--- a/homecam/backend/retention.py
+++ b/homecam/backend/retention.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Iterable
+
+
+def cleanup_old_recordings(directory: Path, retention_days: int) -> Iterable[Path]:
+    """Remove files older than ``retention_days`` and yield removed paths."""
+    cutoff = datetime.utcnow() - timedelta(days=retention_days)
+    removed: list[Path] = []
+    for entry in directory.glob("*.mp4"):
+        mtime = datetime.utcfromtimestamp(entry.stat().st_mtime)
+        if mtime < cutoff:
+            entry.unlink(missing_ok=True)
+            removed.append(entry)
+    return removed

--- a/homecam/frontend/index.html
+++ b/homecam/frontend/index.html
@@ -30,6 +30,9 @@
         label.textContent = cam.name;
         const video = document.createElement('video');
         video.controls = true;
+        video.autoplay = true;
+        video.muted = true;
+        video.playsInline = true;
         div.appendChild(label);
         div.appendChild(video);
         grid.appendChild(div);
@@ -38,8 +41,12 @@
           const hls = new Hls();
           hls.loadSource(url);
           hls.attachMedia(video);
+          hls.on(Hls.Events.MANIFEST_PARSED, () => {
+            video.play();
+          });
         } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
           video.src = url;
+          video.addEventListener('loadedmetadata', () => video.play());
         }
       });
     }

--- a/homecam/frontend/index.html
+++ b/homecam/frontend/index.html
@@ -10,6 +10,9 @@
     #grid { display: flex; flex-wrap: wrap; }
     .cam { width: 33%; box-sizing: border-box; padding: 5px; }
     video { width: 100%; background: black; }
+    #overlay { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.8); display: none; align-items: center; justify-content: center; }
+    #overlay video { width: 80%; max-width: 960px; }
+    #overlay button { position: absolute; top: 10px; right: 20px; font-size: 24px; background: transparent; color: white; border: none; cursor: pointer; }
   </style>
 </head>
 <body>
@@ -18,7 +21,45 @@
     <a href="/manage" style="color: #9cf">Manage Cameras</a>
   </header>
   <div id="grid"></div>
+  <div id="overlay">
+    <button id="close">&times;</button>
+    <video id="highres" controls autoplay></video>
+  </div>
   <script>
+    let overlayHls;
+    function showHighRes(url) {
+      document.querySelectorAll('#grid video').forEach(v => v.pause());
+      const overlay = document.getElementById('overlay');
+      const hv = document.getElementById('highres');
+      overlay.style.display = 'flex';
+      if (overlayHls) {
+        overlayHls.destroy();
+        overlayHls = null;
+      }
+      if (Hls.isSupported()) {
+        overlayHls = new Hls();
+        overlayHls.loadSource(url);
+        overlayHls.attachMedia(hv);
+        overlayHls.on(Hls.Events.MANIFEST_PARSED, () => hv.play());
+      } else if (hv.canPlayType('application/vnd.apple.mpegurl')) {
+        hv.src = url;
+        hv.addEventListener('loadedmetadata', () => hv.play(), { once: true });
+      }
+    }
+    function closeOverlay() {
+      const overlay = document.getElementById('overlay');
+      const hv = document.getElementById('highres');
+      overlay.style.display = 'none';
+      if (overlayHls) {
+        overlayHls.destroy();
+        overlayHls = null;
+      }
+      hv.pause();
+      hv.removeAttribute('src');
+      document.querySelectorAll('#grid video').forEach(v => v.play());
+    }
+    document.getElementById('close').addEventListener('click', closeOverlay);
+    document.getElementById('overlay').addEventListener('click', e => { if (e.target.id === 'overlay') closeOverlay(); });
     async function load() {
       const res = await fetch('/cameras');
       const cams = await res.json();
@@ -33,6 +74,7 @@
         video.autoplay = true;
         video.muted = true;
         video.playsInline = true;
+        video.addEventListener('click', () => showHighRes(cam.stream_urls.high));
         div.appendChild(label);
         div.appendChild(video);
         grid.appendChild(div);

--- a/homecam/frontend/index.html
+++ b/homecam/frontend/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>HomeCam Grid</title>
+  <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
+  <style>
+    body { font-family: sans-serif; margin: 0; }
+    header { padding: 10px; background: #222; color: white; }
+    #grid { display: flex; flex-wrap: wrap; }
+    .cam { width: 33%; box-sizing: border-box; padding: 5px; }
+    video { width: 100%; background: black; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Camera Grid</h1>
+    <a href="/manage" style="color: #9cf">Manage Cameras</a>
+  </header>
+  <div id="grid"></div>
+  <script>
+    async function load() {
+      const res = await fetch('/cameras');
+      const cams = await res.json();
+      const grid = document.getElementById('grid');
+      cams.forEach(cam => {
+        const div = document.createElement('div');
+        div.className = 'cam';
+        const label = document.createElement('div');
+        label.textContent = cam.name;
+        const video = document.createElement('video');
+        video.controls = true;
+        div.appendChild(label);
+        div.appendChild(video);
+        grid.appendChild(div);
+        const url = cam.stream_urls.low;
+        if (Hls.isSupported()) {
+          const hls = new Hls();
+          hls.loadSource(url);
+          hls.attachMedia(video);
+        } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
+          video.src = url;
+        }
+      });
+    }
+    load();
+  </script>
+</body>
+</html>

--- a/homecam/frontend/manage.html
+++ b/homecam/frontend/manage.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Manage Cameras</title>
+  <style>
+    body { font-family: sans-serif; margin: 20px; }
+    form div { margin-bottom: 8px; }
+    table { border-collapse: collapse; width: 100%; margin-top: 20px; }
+    th, td { border: 1px solid #ccc; padding: 6px; text-align: left; }
+  </style>
+</head>
+<body>
+  <h1>Manage Cameras</h1>
+  <form id="cameraForm">
+    <div><label>ID <input type="text" id="id" required></label></div>
+    <div><label>Name <input type="text" id="name" required></label></div>
+    <div><label>RTSP URL <input type="text" id="rtsp_url" required></label></div>
+    <div><label>Storage Path <input type="text" id="storage_path"></label></div>
+    <div><label>Retention Days <input type="number" id="retention_days" value="7" required></label></div>
+    <button type="submit">Save</button>
+  </form>
+
+  <table id="cameraTable">
+    <thead><tr><th>ID</th><th>Name</th><th>Storage</th><th>Actions</th></tr></thead>
+    <tbody></tbody>
+  </table>
+
+  <script>
+    let defaultStorage = '';
+    async function loadDefaults() {
+      const res = await fetch('/defaults');
+      const data = await res.json();
+      defaultStorage = data.storage_path;
+      document.getElementById('storage_path').placeholder = defaultStorage + '/{id}';
+    }
+
+    async function loadCameras() {
+      const res = await fetch('/cameras');
+      const cams = await res.json();
+      const tbody = document.querySelector('#cameraTable tbody');
+      tbody.innerHTML = '';
+      cams.forEach(cam => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${cam.id}</td><td>${cam.name}</td><td>${cam.storage_path}</td><td><button data-id="${cam.id}">Edit</button></td>`;
+        tbody.appendChild(tr);
+      });
+    }
+
+    document.querySelector('#cameraTable').addEventListener('click', e => {
+      if (e.target.tagName === 'BUTTON') {
+        const id = e.target.getAttribute('data-id');
+        fetch('/cameras').then(r => r.json()).then(cams => {
+          const cam = cams.find(c => c.id === id);
+          if (cam) {
+            document.getElementById('id').value = cam.id;
+            document.getElementById('name').value = cam.name;
+            document.getElementById('rtsp_url').value = cam.rtsp_url;
+            document.getElementById('storage_path').value = cam.storage_path;
+            document.getElementById('retention_days').value = cam.retention_days;
+          }
+        });
+      }
+    });
+
+    document.getElementById('cameraForm').addEventListener('submit', async e => {
+      e.preventDefault();
+      const payload = {
+        id: document.getElementById('id').value,
+        name: document.getElementById('name').value,
+        rtsp_url: document.getElementById('rtsp_url').value,
+        storage_path: document.getElementById('storage_path').value.trim() || null,
+        retention_days: parseInt(document.getElementById('retention_days').value, 10)
+      };
+      await fetch('/cameras', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      loadCameras();
+    });
+
+    loadDefaults();
+    loadCameras();
+  </script>
+</body>
+</html>

--- a/homecam/tests/test_camera_manager.py
+++ b/homecam/tests/test_camera_manager.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+
+from homecam.backend.camera_manager import CameraManager
+from homecam.backend.recorder import Recorder
+
+
+def test_manager_starts_recorders_on_init(tmp_path, monkeypatch):
+    config_file = tmp_path / "config.json"
+    storage = tmp_path / "storage"
+    config = {
+        "cam1": {
+            "name": "Cam 1",
+            "rtsp_url": "rtsp://example",
+            "storage_path": str(storage),
+            "retention_days": 1,
+        }
+    }
+    config_file.write_text(json.dumps(config))
+
+    started = []
+
+    def fake_start(self):
+        started.append(self.camera.id)
+
+    monkeypatch.setattr(Recorder, "start", fake_start)
+
+    manager = CameraManager(config_file)
+
+    assert "cam1" in manager.recorders
+    assert started == ["cam1"]

--- a/homecam/tests/test_defaults.py
+++ b/homecam/tests/test_defaults.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import os
+
+os.environ["HOMECAM_TESTING"] = "1"
+
+from fastapi.testclient import TestClient
+
+from homecam.backend import main
+from homecam.backend.recorder import Recorder
+
+
+def test_defaults_endpoint(tmp_path, monkeypatch):
+    monkeypatch.setattr(main, "DEFAULT_STORAGE", tmp_path)
+    client = TestClient(main.app)
+    resp = client.get("/defaults")
+    assert resp.status_code == 200
+    assert resp.json()["storage_path"] == str(tmp_path)
+
+
+def test_add_camera_uses_default_storage(tmp_path, monkeypatch):
+    monkeypatch.setattr(main, "DEFAULT_STORAGE", tmp_path)
+
+    started = []
+
+    def fake_start(self):
+        started.append(self.camera.id)
+
+    monkeypatch.setattr(Recorder, "start", fake_start)
+
+    client = TestClient(main.app)
+    payload = {
+        "id": "cam1",
+        "name": "Cam",
+        "rtsp_url": "rtsp://example",
+        "retention_days": 1,
+    }
+    resp = client.post("/cameras", json=payload)
+    assert resp.status_code == 200
+    assert main.manager.cameras["cam1"].storage_path == tmp_path / "cam1"
+    assert started == ["cam1"]
+    main.manager.remove_camera("cam1")

--- a/homecam/tests/test_retention.py
+++ b/homecam/tests/test_retention.py
@@ -1,0 +1,29 @@
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from homecam.backend.retention import cleanup_old_recordings
+
+
+def test_cleanup_old_recordings(tmp_path: Path) -> None:
+    old_file = tmp_path / "old.mp4"
+    recent_file = tmp_path / "new.mp4"
+    old_file.write_bytes(b"old")
+    recent_file.write_bytes(b"new")
+
+    old_time = datetime.utcnow() - timedelta(days=10)
+    recent_time = datetime.utcnow() - timedelta(days=1)
+    _set_mtime(old_file, old_time)
+    _set_mtime(recent_file, recent_time)
+
+    removed = cleanup_old_recordings(tmp_path, retention_days=5)
+
+    assert old_file in removed
+    assert not old_file.exists()
+    assert recent_file.exists()
+    assert recent_file not in removed
+
+
+def _set_mtime(path: Path, dt: datetime) -> None:
+    ts = dt.timestamp()
+    os.utime(path, (ts, ts))

--- a/homecam/tests/test_streams.py
+++ b/homecam/tests/test_streams.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+import os
+
+os.environ["HOMECAM_TESTING"] = "1"
 
 from fastapi.testclient import TestClient
 

--- a/homecam/tests/test_streams.py
+++ b/homecam/tests/test_streams.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from homecam.backend.camera_manager import CameraConfig
+from homecam.backend.recorder import Recorder
+from homecam.backend import main
+
+
+def test_ffmpeg_command_has_hls_outputs(tmp_path: Path):
+    cam = CameraConfig(
+        id="cam",
+        name="Cam",
+        rtsp_url="rtsp://example",
+        storage_path=tmp_path,
+        retention_days=1,
+    )
+    rec = Recorder(cam)
+    cmd = rec._build_ffmpeg_cmd(
+        tmp_path / "out.mp4",
+        tmp_path / "streams/low/index.m3u8",
+        tmp_path / "streams/high/index.m3u8",
+    )
+    assert str(tmp_path / "out.mp4") in cmd
+    assert str(tmp_path / "streams/low/index.m3u8") in cmd
+    assert str(tmp_path / "streams/high/index.m3u8") in cmd
+    assert cmd.count("hls") == 2
+
+
+def test_stream_endpoint_serves_playlist(tmp_path: Path):
+    cid = "cam1"
+    storage = tmp_path / cid
+    playlist = storage / "streams" / "low" / "index.m3u8"
+    playlist.parent.mkdir(parents=True, exist_ok=True)
+    playlist.write_text("#EXTM3U")
+
+    cam = CameraConfig(
+        id=cid,
+        name="Test",
+        rtsp_url="rtsp://example",
+        storage_path=storage,
+        retention_days=1,
+    )
+    main.manager.cameras[cid] = cam
+    client = TestClient(main.app)
+    try:
+        resp = client.get(f"/streams/{cid}/low/index.m3u8")
+        assert resp.status_code == 200
+        assert resp.text.startswith("#EXTM3U")
+    finally:
+        main.manager.cameras.pop(cid, None)

--- a/homecam/tests/test_streams.py
+++ b/homecam/tests/test_streams.py
@@ -21,6 +21,8 @@ def test_ffmpeg_command_has_hls_outputs(tmp_path: Path):
         tmp_path / "streams/low/index.m3u8",
         tmp_path / "streams/high/index.m3u8",
     )
+    assert "-rtsp_transport" in cmd
+    assert "tcp" in cmd
     assert str(tmp_path / "out.mp4") in cmd
     assert str(tmp_path / "streams/low/index.m3u8") in cmd
     assert str(tmp_path / "streams/high/index.m3u8") in cmd


### PR DESCRIPTION
## Summary
- Manage camera configs and spawn ffmpeg recorders for RTSP streams
- Provide FastAPI endpoints to add, list, and delete cameras with retention settings
- Include retention cleanup utility, tests, and usage documentation

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pip install fastapi pydantic uvicorn websockets`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaa24e9eec832784604f558e2b6053